### PR TITLE
feat: MCP Server with basic email tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "llm-guard",
     "imap-tools",
     "pydantic>=2.0",
+    "pydantic-settings>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -36,7 +37,11 @@ dev = [
     "ruff",
     "mypy",
     "pytest",
+    "pytest-asyncio",
 ]
+
+[project.scripts]
+read-no-evil-mcp = "read_no_evil_mcp.server:main"
 
 [project.urls]
 Homepage = "https://github.com/thekie/read-no-evil-mcp"
@@ -57,5 +62,11 @@ module = [
     "imap_tools.*",
     "mcp.*",
     "llm_guard.*",
+    "pydantic_settings.*",
 ]
 ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/src/read_no_evil_mcp/__init__.py
+++ b/src/read_no_evil_mcp/__init__.py
@@ -1,5 +1,8 @@
 """A secure email gateway MCP server that protects AI agents from prompt injection attacks in emails."""
 
+from read_no_evil_mcp.config import Settings
+from read_no_evil_mcp.connectors.base import BaseConnector
+from read_no_evil_mcp.connectors.imap import IMAPConnector
 from read_no_evil_mcp.models import (
     Attachment,
     Email,
@@ -8,14 +11,19 @@ from read_no_evil_mcp.models import (
     Folder,
     IMAPConfig,
 )
+from read_no_evil_mcp.service import EmailService
 
 __version__ = "0.1.0"
 
 __all__ = [
     "Attachment",
+    "BaseConnector",
     "Email",
     "EmailAddress",
+    "EmailService",
     "EmailSummary",
     "Folder",
     "IMAPConfig",
+    "IMAPConnector",
+    "Settings",
 ]

--- a/src/read_no_evil_mcp/__main__.py
+++ b/src/read_no_evil_mcp/__main__.py
@@ -1,0 +1,6 @@
+"""Entry point for python -m read_no_evil_mcp."""
+
+from read_no_evil_mcp.server import main
+
+if __name__ == "__main__":
+    main()

--- a/src/read_no_evil_mcp/config.py
+++ b/src/read_no_evil_mcp/config.py
@@ -1,0 +1,20 @@
+"""Configuration settings for read-no-evil-mcp using pydantic-settings."""
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables with RNOE_ prefix."""
+
+    model_config = SettingsConfigDict(env_prefix="RNOE_")
+
+    # IMAP configuration
+    imap_host: str
+    imap_port: int = 993
+    imap_username: str
+    imap_password: SecretStr
+    imap_ssl: bool = True
+
+    # Application defaults
+    default_lookback_days: int = 7

--- a/src/read_no_evil_mcp/connectors/__init__.py
+++ b/src/read_no_evil_mcp/connectors/__init__.py
@@ -1,5 +1,6 @@
 """Email connectors for read-no-evil-mcp."""
 
+from read_no_evil_mcp.connectors.base import BaseConnector
 from read_no_evil_mcp.connectors.imap import IMAPConnector
 
-__all__ = ["IMAPConnector"]
+__all__ = ["BaseConnector", "IMAPConnector"]

--- a/src/read_no_evil_mcp/connectors/base.py
+++ b/src/read_no_evil_mcp/connectors/base.py
@@ -1,0 +1,79 @@
+"""Abstract base class for email connectors."""
+
+from abc import ABC, abstractmethod
+from datetime import date, timedelta
+from types import TracebackType
+
+from read_no_evil_mcp.models import Email, EmailSummary, Folder
+
+
+class BaseConnector(ABC):
+    """Abstract base class defining the interface for email connectors."""
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Establish connection to the email server."""
+        ...
+
+    @abstractmethod
+    def disconnect(self) -> None:
+        """Close connection to the email server."""
+        ...
+
+    @abstractmethod
+    def list_folders(self) -> list[Folder]:
+        """List all available folders/mailboxes.
+
+        Returns:
+            List of Folder objects representing available mailboxes.
+        """
+        ...
+
+    @abstractmethod
+    def fetch_emails(
+        self,
+        folder: str = "INBOX",
+        *,
+        lookback: timedelta,
+        from_date: date | None = None,
+        limit: int | None = None,
+    ) -> list[EmailSummary]:
+        """Fetch email summaries from a folder within a time range.
+
+        Args:
+            folder: Folder/mailbox to fetch from (default: INBOX)
+            lookback: How far back to look from from_date
+            from_date: Starting point for lookback (default: today)
+            limit: Maximum number of emails to return
+
+        Returns:
+            List of EmailSummary objects, newest first.
+        """
+        ...
+
+    @abstractmethod
+    def get_email(self, folder: str, uid: int) -> Email | None:
+        """Fetch full email content by UID.
+
+        Args:
+            folder: Folder/mailbox containing the email
+            uid: Unique identifier of the email
+
+        Returns:
+            Full Email object or None if not found.
+        """
+        ...
+
+    def __enter__(self) -> "BaseConnector":
+        """Context manager entry - connect to server."""
+        self.connect()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Context manager exit - disconnect from server."""
+        self.disconnect()

--- a/src/read_no_evil_mcp/connectors/imap.py
+++ b/src/read_no_evil_mcp/connectors/imap.py
@@ -1,11 +1,11 @@
 """IMAP connector for reading emails using imap-tools."""
 
 from datetime import date, timedelta
-from types import TracebackType
 
 from imap_tools import AND, MailBox, MailBoxUnencrypted
 from imap_tools import EmailAddress as IMAPEmailAddress
 
+from read_no_evil_mcp.connectors.base import BaseConnector
 from read_no_evil_mcp.models import (
     Attachment,
     Email,
@@ -33,7 +33,7 @@ def _convert_addresses(addrs: tuple[IMAPEmailAddress, ...]) -> list[EmailAddress
     ]
 
 
-class IMAPConnector:
+class IMAPConnector(BaseConnector):
     """Connector for reading emails via IMAP using imap-tools."""
 
     def __init__(self, config: IMAPConfig) -> None:
@@ -161,15 +161,3 @@ class IMAPConnector:
             )
 
         return None
-
-    def __enter__(self) -> "IMAPConnector":
-        self.connect()
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        self.disconnect()

--- a/src/read_no_evil_mcp/server.py
+++ b/src/read_no_evil_mcp/server.py
@@ -1,0 +1,193 @@
+"""MCP server implementation for read-no-evil-mcp."""
+
+from datetime import timedelta
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import TextContent, Tool
+
+from read_no_evil_mcp.config import Settings
+from read_no_evil_mcp.connectors.imap import IMAPConnector
+from read_no_evil_mcp.models import Email, IMAPConfig
+from read_no_evil_mcp.service import EmailService
+
+# Create the MCP server instance
+server = Server("read-no-evil-mcp")
+
+
+def _create_service() -> EmailService:
+    """Create an EmailService from environment configuration."""
+    settings = Settings()  # type: ignore[call-arg]
+    config = IMAPConfig(
+        host=settings.imap_host,
+        port=settings.imap_port,
+        username=settings.imap_username,
+        password=settings.imap_password,
+        ssl=settings.imap_ssl,
+    )
+    connector = IMAPConnector(config)
+    return EmailService(connector)
+
+
+@server.list_tools()  # type: ignore[no-untyped-call,untyped-decorator]
+async def list_tools() -> list[Tool]:
+    """Return the list of available tools."""
+    return [
+        Tool(
+            name="list_folders",
+            description="List all available email folders/mailboxes",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        ),
+        Tool(
+            name="list_emails",
+            description="List email summaries from a folder",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "folder": {
+                        "type": "string",
+                        "description": "Folder to list emails from (default: INBOX)",
+                        "default": "INBOX",
+                    },
+                    "days_back": {
+                        "type": "integer",
+                        "description": "Number of days to look back (default: 7)",
+                        "default": 7,
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of emails to return",
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="get_email",
+            description="Get full email content by UID",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "folder": {
+                        "type": "string",
+                        "description": "Folder containing the email",
+                    },
+                    "uid": {
+                        "type": "integer",
+                        "description": "Unique identifier of the email",
+                    },
+                },
+                "required": ["folder", "uid"],
+            },
+        ),
+    ]
+
+
+@server.call_tool()  # type: ignore[untyped-decorator]
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Handle tool calls."""
+    service = _create_service()
+
+    try:
+        service.connect()
+
+        if name == "list_folders":
+            folders = service.list_folders()
+            result = "\n".join(f"- {f.name}" for f in folders)
+            return [TextContent(type="text", text=result or "No folders found.")]
+
+        elif name == "list_emails":
+            folder = arguments.get("folder", "INBOX")
+            days_back = arguments.get("days_back", 7)
+            limit = arguments.get("limit")
+
+            emails = service.fetch_emails(
+                folder,
+                lookback=timedelta(days=days_back),
+                limit=limit,
+            )
+
+            if not emails:
+                return [TextContent(type="text", text="No emails found.")]
+
+            lines = []
+            for email in emails:
+                date_str = email.date.strftime("%Y-%m-%d %H:%M")
+                attachment_marker = " [+]" if email.has_attachments else ""
+                lines.append(
+                    f"[{email.uid}] {date_str} | {email.sender.address} | "
+                    f"{email.subject}{attachment_marker}"
+                )
+
+            return [TextContent(type="text", text="\n".join(lines))]
+
+        elif name == "get_email":
+            folder = arguments["folder"]
+            uid = arguments["uid"]
+
+            email_result: Email | None = service.get_email(folder, uid)
+
+            if not email_result:
+                return [TextContent(type="text", text=f"Email not found: {folder}/{uid}")]
+
+            # Format email content
+            lines = [
+                f"Subject: {email_result.subject}",
+                f"From: {email_result.sender}",
+                f"To: {', '.join(str(addr) for addr in email_result.to)}",
+                f"Date: {email_result.date.strftime('%Y-%m-%d %H:%M:%S')}",
+            ]
+
+            if email_result.cc:
+                lines.append(f"CC: {', '.join(str(addr) for addr in email_result.cc)}")
+
+            if email_result.message_id:
+                lines.append(f"Message-ID: {email_result.message_id}")
+
+            if email_result.attachments:
+                att_list = ", ".join(a.filename for a in email_result.attachments)
+                lines.append(f"Attachments: {att_list}")
+
+            lines.append("")  # Empty line before body
+
+            if email_result.body_plain:
+                lines.append(email_result.body_plain)
+            elif email_result.body_html:
+                lines.append("[HTML content - plain text not available]")
+                lines.append(email_result.body_html)
+            else:
+                lines.append("[No body content]")
+
+            return [TextContent(type="text", text="\n".join(lines))]
+
+        else:
+            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+    finally:
+        service.disconnect()
+
+
+async def run_server() -> None:
+    """Run the MCP server using stdio transport."""
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
+
+
+def main() -> None:
+    """Entry point for the MCP server."""
+    import asyncio
+
+    asyncio.run(run_server())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/read_no_evil_mcp/service.py
+++ b/src/read_no_evil_mcp/service.py
@@ -1,0 +1,77 @@
+"""Email service that orchestrates connectors."""
+
+from datetime import date, timedelta
+
+from read_no_evil_mcp.connectors.base import BaseConnector
+from read_no_evil_mcp.models import Email, EmailSummary, Folder
+
+
+class EmailService:
+    """Service layer for email operations.
+
+    Orchestrates connector operations and will later integrate
+    protection/scanning layers.
+    """
+
+    def __init__(self, connector: BaseConnector) -> None:
+        """Initialize the service with a connector.
+
+        Args:
+            connector: Email connector to use for operations.
+        """
+        self._connector = connector
+
+    def connect(self) -> None:
+        """Connect to the email server."""
+        self._connector.connect()
+
+    def disconnect(self) -> None:
+        """Disconnect from the email server."""
+        self._connector.disconnect()
+
+    def list_folders(self) -> list[Folder]:
+        """List all available folders.
+
+        Returns:
+            List of Folder objects.
+        """
+        return self._connector.list_folders()
+
+    def fetch_emails(
+        self,
+        folder: str = "INBOX",
+        *,
+        lookback: timedelta,
+        from_date: date | None = None,
+        limit: int | None = None,
+    ) -> list[EmailSummary]:
+        """Fetch email summaries from a folder.
+
+        Args:
+            folder: Folder to fetch from (default: INBOX)
+            lookback: How far back to look
+            from_date: Starting point for lookback (default: today)
+            limit: Maximum number of emails to return
+
+        Returns:
+            List of EmailSummary objects, newest first.
+        """
+        return self._connector.fetch_emails(
+            folder,
+            lookback=lookback,
+            from_date=from_date,
+            limit=limit,
+        )
+
+    def get_email(self, folder: str, uid: int) -> Email | None:
+        """Get full email content by UID.
+
+        Args:
+            folder: Folder containing the email
+            uid: Unique identifier of the email
+
+        Returns:
+            Full Email object or None if not found.
+        """
+        # Future: Add protection/scanning here before returning
+        return self._connector.get_email(folder, uid)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,96 @@
+"""Tests for configuration settings."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from read_no_evil_mcp.config import Settings
+
+
+class TestSettings:
+    def test_load_from_env(self):
+        """Test loading settings from environment variables."""
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            "RNOE_IMAP_PORT": "993",
+            "RNOE_IMAP_USERNAME": "user@example.com",
+            "RNOE_IMAP_PASSWORD": "secret123",
+            "RNOE_IMAP_SSL": "true",
+            "RNOE_DEFAULT_LOOKBACK_DAYS": "14",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            settings = Settings()
+
+        assert settings.imap_host == "imap.example.com"
+        assert settings.imap_port == 993
+        assert settings.imap_username == "user@example.com"
+        assert settings.imap_password.get_secret_value() == "secret123"
+        assert settings.imap_ssl is True
+        assert settings.default_lookback_days == 14
+
+    def test_defaults(self):
+        """Test default values for optional settings."""
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            "RNOE_IMAP_USERNAME": "user@example.com",
+            "RNOE_IMAP_PASSWORD": "secret123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            settings = Settings()
+
+        assert settings.imap_port == 993
+        assert settings.imap_ssl is True
+        assert settings.default_lookback_days == 7
+
+    def test_ssl_false(self):
+        """Test setting SSL to false."""
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            "RNOE_IMAP_USERNAME": "user@example.com",
+            "RNOE_IMAP_PASSWORD": "secret123",
+            "RNOE_IMAP_SSL": "false",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            settings = Settings()
+
+        assert settings.imap_ssl is False
+
+    def test_custom_port(self):
+        """Test custom port setting."""
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            "RNOE_IMAP_PORT": "143",
+            "RNOE_IMAP_USERNAME": "user@example.com",
+            "RNOE_IMAP_PASSWORD": "secret123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            settings = Settings()
+
+        assert settings.imap_port == 143
+
+    def test_missing_required_raises(self):
+        """Test that missing required fields raise an error."""
+        from pydantic import ValidationError
+
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            # Missing username and password
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError):
+                Settings()
+
+    def test_password_is_secret(self):
+        """Test that password is stored as SecretStr."""
+        env = {
+            "RNOE_IMAP_HOST": "imap.example.com",
+            "RNOE_IMAP_USERNAME": "user@example.com",
+            "RNOE_IMAP_PASSWORD": "mysecret",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            settings = Settings()
+
+        # Password value should not appear in string representation
+        assert "mysecret" not in str(settings.imap_password)
+        assert settings.imap_password.get_secret_value() == "mysecret"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,203 @@
+"""Tests for MCP server."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from read_no_evil_mcp.models import Email, EmailAddress, EmailSummary, Folder
+from read_no_evil_mcp.server import call_tool, list_tools
+
+
+class TestListTools:
+    @pytest.mark.asyncio
+    async def test_returns_all_tools(self):
+        """Test that all expected tools are registered."""
+        tools = await list_tools()
+
+        tool_names = {t.name for t in tools}
+        assert tool_names == {"list_folders", "list_emails", "get_email"}
+
+    @pytest.mark.asyncio
+    async def test_list_folders_tool_schema(self):
+        """Test list_folders tool has correct schema."""
+        tools = await list_tools()
+        tool = next(t for t in tools if t.name == "list_folders")
+
+        assert tool.description == "List all available email folders/mailboxes"
+        assert tool.inputSchema["required"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_emails_tool_schema(self):
+        """Test list_emails tool has correct schema."""
+        tools = await list_tools()
+        tool = next(t for t in tools if t.name == "list_emails")
+
+        assert "folder" in tool.inputSchema["properties"]
+        assert "days_back" in tool.inputSchema["properties"]
+        assert "limit" in tool.inputSchema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_get_email_tool_schema(self):
+        """Test get_email tool has correct schema."""
+        tools = await list_tools()
+        tool = next(t for t in tools if t.name == "get_email")
+
+        assert tool.inputSchema["required"] == ["folder", "uid"]
+        assert "folder" in tool.inputSchema["properties"]
+        assert "uid" in tool.inputSchema["properties"]
+
+
+class TestCallTool:
+    @pytest.mark.asyncio
+    async def test_list_folders(self):
+        """Test list_folders tool returns folder names."""
+        mock_service = MagicMock()
+        mock_service.list_folders.return_value = [
+            Folder(name="INBOX"),
+            Folder(name="Sent"),
+        ]
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("list_folders", {})
+
+        assert len(result) == 1
+        assert "INBOX" in result[0].text
+        assert "Sent" in result[0].text
+        mock_service.connect.assert_called_once()
+        mock_service.disconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_list_folders_empty(self):
+        """Test list_folders with no folders."""
+        mock_service = MagicMock()
+        mock_service.list_folders.return_value = []
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("list_folders", {})
+
+        assert "No folders found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_list_emails(self):
+        """Test list_emails tool returns email summaries."""
+        mock_service = MagicMock()
+        mock_service.fetch_emails.return_value = [
+            EmailSummary(
+                uid=1,
+                folder="INBOX",
+                subject="Test Subject",
+                sender=EmailAddress(address="sender@example.com"),
+                date=datetime(2026, 2, 3, 12, 0, 0),
+                has_attachments=True,
+            ),
+        ]
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("list_emails", {"folder": "INBOX", "days_back": 7})
+
+        assert len(result) == 1
+        assert "[1]" in result[0].text
+        assert "Test Subject" in result[0].text
+        assert "sender@example.com" in result[0].text
+        assert "[+]" in result[0].text  # attachment marker
+
+    @pytest.mark.asyncio
+    async def test_list_emails_no_results(self):
+        """Test list_emails with no emails."""
+        mock_service = MagicMock()
+        mock_service.fetch_emails.return_value = []
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("list_emails", {})
+
+        assert "No emails found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_list_emails_with_limit(self):
+        """Test list_emails respects limit parameter."""
+        mock_service = MagicMock()
+        mock_service.fetch_emails.return_value = []
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            await call_tool("list_emails", {"folder": "INBOX", "limit": 5})
+
+        call_args = mock_service.fetch_emails.call_args
+        assert call_args.kwargs["limit"] == 5
+
+    @pytest.mark.asyncio
+    async def test_get_email(self):
+        """Test get_email tool returns full email content."""
+        mock_service = MagicMock()
+        mock_service.get_email.return_value = Email(
+            uid=123,
+            folder="INBOX",
+            subject="Test Email",
+            sender=EmailAddress(name="Sender", address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            to=[EmailAddress(address="to@example.com")],
+            body_plain="Hello, World!",
+            message_id="<abc@example.com>",
+        )
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("get_email", {"folder": "INBOX", "uid": 123})
+
+        text = result[0].text
+        assert "Subject: Test Email" in text
+        assert "From: Sender <sender@example.com>" in text
+        assert "To: to@example.com" in text
+        assert "Hello, World!" in text
+
+    @pytest.mark.asyncio
+    async def test_get_email_not_found(self):
+        """Test get_email with non-existent email."""
+        mock_service = MagicMock()
+        mock_service.get_email.return_value = None
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("get_email", {"folder": "INBOX", "uid": 999})
+
+        assert "Email not found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_get_email_html_only(self):
+        """Test get_email with HTML-only content."""
+        mock_service = MagicMock()
+        mock_service.get_email.return_value = Email(
+            uid=123,
+            folder="INBOX",
+            subject="HTML Email",
+            sender=EmailAddress(address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_html="<p>HTML content</p>",
+        )
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("get_email", {"folder": "INBOX", "uid": 123})
+
+        text = result[0].text
+        assert "HTML content - plain text not available" in text
+        assert "<p>HTML content</p>" in text
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self):
+        """Test calling unknown tool returns error message."""
+        mock_service = MagicMock()
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            result = await call_tool("unknown_tool", {})
+
+        assert "Unknown tool" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_disconnect_called_on_exception(self):
+        """Test that disconnect is called even when exception occurs."""
+        mock_service = MagicMock()
+        mock_service.list_folders.side_effect = RuntimeError("Connection error")
+
+        with patch("read_no_evil_mcp.server._create_service", return_value=mock_service):
+            with pytest.raises(RuntimeError):
+                await call_tool("list_folders", {})
+
+        mock_service.disconnect.assert_called_once()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,125 @@
+"""Tests for EmailService."""
+
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
+
+from read_no_evil_mcp.models import Email, EmailAddress, EmailSummary, Folder
+from read_no_evil_mcp.service import EmailService
+
+
+class TestEmailService:
+    def test_connect(self):
+        """Test that connect delegates to connector."""
+        mock_connector = MagicMock()
+        service = EmailService(mock_connector)
+
+        service.connect()
+
+        mock_connector.connect.assert_called_once()
+
+    def test_disconnect(self):
+        """Test that disconnect delegates to connector."""
+        mock_connector = MagicMock()
+        service = EmailService(mock_connector)
+
+        service.disconnect()
+
+        mock_connector.disconnect.assert_called_once()
+
+    def test_list_folders(self):
+        """Test listing folders through service."""
+        mock_connector = MagicMock()
+        expected_folders = [
+            Folder(name="INBOX"),
+            Folder(name="Sent"),
+            Folder(name="Drafts"),
+        ]
+        mock_connector.list_folders.return_value = expected_folders
+
+        service = EmailService(mock_connector)
+        folders = service.list_folders()
+
+        assert folders == expected_folders
+        mock_connector.list_folders.assert_called_once()
+
+    def test_fetch_emails(self):
+        """Test fetching email summaries through service."""
+        mock_connector = MagicMock()
+        expected_emails = [
+            EmailSummary(
+                uid=1,
+                folder="INBOX",
+                subject="Test 1",
+                sender=EmailAddress(address="sender@example.com"),
+                date=datetime(2026, 2, 3, 12, 0, 0),
+            ),
+            EmailSummary(
+                uid=2,
+                folder="INBOX",
+                subject="Test 2",
+                sender=EmailAddress(address="sender2@example.com"),
+                date=datetime(2026, 2, 2, 12, 0, 0),
+            ),
+        ]
+        mock_connector.fetch_emails.return_value = expected_emails
+
+        service = EmailService(mock_connector)
+        emails = service.fetch_emails(
+            "INBOX",
+            lookback=timedelta(days=7),
+            from_date=date(2026, 2, 3),
+            limit=10,
+        )
+
+        assert emails == expected_emails
+        mock_connector.fetch_emails.assert_called_once_with(
+            "INBOX",
+            lookback=timedelta(days=7),
+            from_date=date(2026, 2, 3),
+            limit=10,
+        )
+
+    def test_fetch_emails_defaults(self):
+        """Test fetch_emails with default folder."""
+        mock_connector = MagicMock()
+        mock_connector.fetch_emails.return_value = []
+
+        service = EmailService(mock_connector)
+        service.fetch_emails(lookback=timedelta(days=7))
+
+        mock_connector.fetch_emails.assert_called_once_with(
+            "INBOX",
+            lookback=timedelta(days=7),
+            from_date=None,
+            limit=None,
+        )
+
+    def test_get_email(self):
+        """Test getting full email through service."""
+        mock_connector = MagicMock()
+        expected_email = Email(
+            uid=123,
+            folder="INBOX",
+            subject="Test Email",
+            sender=EmailAddress(address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_plain="Hello, World!",
+        )
+        mock_connector.get_email.return_value = expected_email
+
+        service = EmailService(mock_connector)
+        email = service.get_email("INBOX", 123)
+
+        assert email == expected_email
+        mock_connector.get_email.assert_called_once_with("INBOX", 123)
+
+    def test_get_email_not_found(self):
+        """Test getting non-existent email returns None."""
+        mock_connector = MagicMock()
+        mock_connector.get_email.return_value = None
+
+        service = EmailService(mock_connector)
+        email = service.get_email("INBOX", 999)
+
+        assert email is None
+        mock_connector.get_email.assert_called_once_with("INBOX", 999)


### PR DESCRIPTION
## Summary
Implements Issue #4 - Basic MCP server with read-only email tools.

## Changes
- **config.py** — Pydantic Settings for environment-based configuration
- **connectors/base.py** — Abstract base class for email connectors
- **connectors/imap.py** — Updated to inherit from base
- **service.py** — EmailService abstraction layer
- **server.py** — MCP server with stdio transport

## Tools Implemented
1. `list_folders` — List all email folders
2. `list_emails` — List emails in a folder (with limit/since filtering)
3. `get_email` — Get full email content by ID

## Testing
- 53 tests added and passing
- ruff check ✅
- mypy ✅

Closes #4