### PR TITLE
refactor: modularize MCP tools architecture

### DIFF
--- a/src/read_no_evil_mcp/server.py
+++ b/src/read_no_evil_mcp/server.py
@@ -1,6 +1,5 @@
 """MCP server implementation for read-no-evil-mcp."""
 
-from datetime import timedelta
 from typing import Any
 
 from mcp.server import Server
@@ -9,8 +8,9 @@ from mcp.types import TextContent, Tool
 
 from read_no_evil_mcp.config import Settings
 from read_no_evil_mcp.connectors.imap import IMAPConnector
-from read_no_evil_mcp.models import Email, IMAPConfig
+from read_no_evil_mcp.models import IMAPConfig
 from read_no_evil_mcp.service import EmailService
+from read_no_evil_mcp.tools import execute_tool, get_all_tools
 
 # Create the MCP server instance
 server = Server("read-no-evil-mcp")
@@ -33,59 +33,7 @@ def _create_service() -> EmailService:
 @server.list_tools()  # type: ignore[no-untyped-call,untyped-decorator]
 async def list_tools() -> list[Tool]:
     """Return the list of available tools."""
-    return [
-        Tool(
-            name="list_folders",
-            description="List all available email folders/mailboxes",
-            inputSchema={
-                "type": "object",
-                "properties": {},
-                "required": [],
-            },
-        ),
-        Tool(
-            name="list_emails",
-            description="List email summaries from a folder",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "folder": {
-                        "type": "string",
-                        "description": "Folder to list emails from (default: INBOX)",
-                        "default": "INBOX",
-                    },
-                    "days_back": {
-                        "type": "integer",
-                        "description": "Number of days to look back (default: 7)",
-                        "default": 7,
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of emails to return",
-                    },
-                },
-                "required": [],
-            },
-        ),
-        Tool(
-            name="get_email",
-            description="Get full email content by UID",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "folder": {
-                        "type": "string",
-                        "description": "Folder containing the email",
-                    },
-                    "uid": {
-                        "type": "integer",
-                        "description": "Unique identifier of the email",
-                    },
-                },
-                "required": ["folder", "uid"],
-            },
-        ),
-    ]
+    return get_all_tools()
 
 
 @server.call_tool()  # type: ignore[untyped-decorator]
@@ -95,79 +43,9 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
     try:
         service.connect()
-
-        if name == "list_folders":
-            folders = service.list_folders()
-            result = "\n".join(f"- {f.name}" for f in folders)
-            return [TextContent(type="text", text=result or "No folders found.")]
-
-        elif name == "list_emails":
-            folder = arguments.get("folder", "INBOX")
-            days_back = arguments.get("days_back", 7)
-            limit = arguments.get("limit")
-
-            emails = service.fetch_emails(
-                folder,
-                lookback=timedelta(days=days_back),
-                limit=limit,
-            )
-
-            if not emails:
-                return [TextContent(type="text", text="No emails found.")]
-
-            lines = []
-            for email in emails:
-                date_str = email.date.strftime("%Y-%m-%d %H:%M")
-                attachment_marker = " [+]" if email.has_attachments else ""
-                lines.append(
-                    f"[{email.uid}] {date_str} | {email.sender.address} | "
-                    f"{email.subject}{attachment_marker}"
-                )
-
-            return [TextContent(type="text", text="\n".join(lines))]
-
-        elif name == "get_email":
-            folder = arguments["folder"]
-            uid = arguments["uid"]
-
-            email_result: Email | None = service.get_email(folder, uid)
-
-            if not email_result:
-                return [TextContent(type="text", text=f"Email not found: {folder}/{uid}")]
-
-            # Format email content
-            lines = [
-                f"Subject: {email_result.subject}",
-                f"From: {email_result.sender}",
-                f"To: {', '.join(str(addr) for addr in email_result.to)}",
-                f"Date: {email_result.date.strftime('%Y-%m-%d %H:%M:%S')}",
-            ]
-
-            if email_result.cc:
-                lines.append(f"CC: {', '.join(str(addr) for addr in email_result.cc)}")
-
-            if email_result.message_id:
-                lines.append(f"Message-ID: {email_result.message_id}")
-
-            if email_result.attachments:
-                att_list = ", ".join(a.filename for a in email_result.attachments)
-                lines.append(f"Attachments: {att_list}")
-
-            lines.append("")  # Empty line before body
-
-            if email_result.body_plain:
-                lines.append(email_result.body_plain)
-            elif email_result.body_html:
-                lines.append("[HTML content - plain text not available]")
-                lines.append(email_result.body_html)
-            else:
-                lines.append("[No body content]")
-
-            return [TextContent(type="text", text="\n".join(lines))]
-
-        else:
-            return [TextContent(type="text", text=f"Unknown tool: {name}")]
-
+        return execute_tool(name, arguments, service)
+    except KeyError:
+        return [TextContent(type="text", text=f"Unknown tool: {name}")]
     finally:
         service.disconnect()
 

--- a/src/read_no_evil_mcp/tools/__init__.py
+++ b/src/read_no_evil_mcp/tools/__init__.py
@@ -1,0 +1,25 @@
+"""Tools registry with auto-discovery and decorator-based registration."""
+
+# isort: skip_file
+
+from read_no_evil_mcp.tools.base import BaseTool
+from read_no_evil_mcp.tools.registry import (
+    execute_tool,
+    get_all_tools,
+    get_tool_names,
+    register_tool,
+)
+
+# Import tool modules to trigger registration via decorators
+# These must be imported after registry to avoid circular imports
+from read_no_evil_mcp.tools import get_email as _get_email  # noqa: F401
+from read_no_evil_mcp.tools import list_emails as _list_emails  # noqa: F401
+from read_no_evil_mcp.tools import list_folders as _list_folders  # noqa: F401
+
+__all__ = [
+    "BaseTool",
+    "execute_tool",
+    "get_all_tools",
+    "get_tool_names",
+    "register_tool",
+]

--- a/src/read_no_evil_mcp/tools/base.py
+++ b/src/read_no_evil_mcp/tools/base.py
@@ -1,0 +1,50 @@
+"""Abstract base class for MCP tools."""
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from mcp.types import TextContent
+
+from read_no_evil_mcp.service import EmailService
+
+
+class BaseTool(ABC):
+    """Abstract base class defining the interface for MCP tools.
+
+    Subclasses must define class-level attributes for name, description,
+    and input_schema, and implement the execute method.
+
+    Usage:
+        @register_tool
+        class MyTool(BaseTool):
+            name = "my_tool"
+            description = "Does something useful"
+            input_schema = {"type": "object", "properties": {}, "required": []}
+
+            def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+                ...
+    """
+
+    name: ClassVar[str]
+    description: ClassVar[str]
+    input_schema: ClassVar[dict[str, Any]]
+
+    def __init__(self, service: EmailService) -> None:
+        """Initialize the tool with an EmailService instance.
+
+        Args:
+            service: Connected EmailService for email operations
+        """
+        self.service = service
+
+    @abstractmethod
+    def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        """Execute the tool with the given arguments.
+
+        Args:
+            arguments: Tool arguments matching the input_schema
+
+        Returns:
+            List of TextContent results
+        """
+        ...

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -1,0 +1,78 @@
+"""Get email tool implementation."""
+
+from typing import Any, ClassVar
+
+from mcp.types import TextContent
+
+from read_no_evil_mcp.models import Email
+from read_no_evil_mcp.tools.base import BaseTool
+from read_no_evil_mcp.tools.registry import register_tool
+
+
+@register_tool
+class GetEmailTool(BaseTool):
+    """Tool to get full email content by UID."""
+
+    name: ClassVar[str] = "get_email"
+    description: ClassVar[str] = "Get full email content by UID"
+    input_schema: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "folder": {
+                "type": "string",
+                "description": "Folder containing the email",
+            },
+            "uid": {
+                "type": "integer",
+                "description": "Unique identifier of the email",
+            },
+        },
+        "required": ["folder", "uid"],
+    }
+
+    def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        """Execute the get_email tool.
+
+        Args:
+            arguments: Dict with required folder and uid
+
+        Returns:
+            List containing a single TextContent with full email content
+        """
+        folder = arguments["folder"]
+        uid = arguments["uid"]
+
+        email_result: Email | None = self.service.get_email(folder, uid)
+
+        if not email_result:
+            return [TextContent(type="text", text=f"Email not found: {folder}/{uid}")]
+
+        # Format email content
+        lines = [
+            f"Subject: {email_result.subject}",
+            f"From: {email_result.sender}",
+            f"To: {', '.join(str(addr) for addr in email_result.to)}",
+            f"Date: {email_result.date.strftime('%Y-%m-%d %H:%M:%S')}",
+        ]
+
+        if email_result.cc:
+            lines.append(f"CC: {', '.join(str(addr) for addr in email_result.cc)}")
+
+        if email_result.message_id:
+            lines.append(f"Message-ID: {email_result.message_id}")
+
+        if email_result.attachments:
+            att_list = ", ".join(a.filename for a in email_result.attachments)
+            lines.append(f"Attachments: {att_list}")
+
+        lines.append("")  # Empty line before body
+
+        if email_result.body_plain:
+            lines.append(email_result.body_plain)
+        elif email_result.body_html:
+            lines.append("[HTML content - plain text not available]")
+            lines.append(email_result.body_html)
+        else:
+            lines.append("[No body content]")
+
+        return [TextContent(type="text", text="\n".join(lines))]

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -1,0 +1,70 @@
+"""List emails tool implementation."""
+
+from datetime import timedelta
+from typing import Any, ClassVar
+
+from mcp.types import TextContent
+
+from read_no_evil_mcp.tools.base import BaseTool
+from read_no_evil_mcp.tools.registry import register_tool
+
+
+@register_tool
+class ListEmailsTool(BaseTool):
+    """Tool to list email summaries from a folder."""
+
+    name: ClassVar[str] = "list_emails"
+    description: ClassVar[str] = "List email summaries from a folder"
+    input_schema: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "folder": {
+                "type": "string",
+                "description": "Folder to list emails from (default: INBOX)",
+                "default": "INBOX",
+            },
+            "days_back": {
+                "type": "integer",
+                "description": "Number of days to look back (default: 7)",
+                "default": 7,
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of emails to return",
+            },
+        },
+        "required": [],
+    }
+
+    def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        """Execute the list_emails tool.
+
+        Args:
+            arguments: Dict with optional folder, days_back, and limit
+
+        Returns:
+            List containing a single TextContent with email summaries
+        """
+        folder = arguments.get("folder", "INBOX")
+        days_back = arguments.get("days_back", 7)
+        limit = arguments.get("limit")
+
+        emails = self.service.fetch_emails(
+            folder,
+            lookback=timedelta(days=days_back),
+            limit=limit,
+        )
+
+        if not emails:
+            return [TextContent(type="text", text="No emails found.")]
+
+        lines = []
+        for email in emails:
+            date_str = email.date.strftime("%Y-%m-%d %H:%M")
+            attachment_marker = " [+]" if email.has_attachments else ""
+            lines.append(
+                f"[{email.uid}] {date_str} | {email.sender.address} | "
+                f"{email.subject}{attachment_marker}"
+            )
+
+        return [TextContent(type="text", text="\n".join(lines))]

--- a/src/read_no_evil_mcp/tools/list_folders.py
+++ b/src/read_no_evil_mcp/tools/list_folders.py
@@ -1,0 +1,34 @@
+"""List folders tool implementation."""
+
+from typing import Any, ClassVar
+
+from mcp.types import TextContent
+
+from read_no_evil_mcp.tools.base import BaseTool
+from read_no_evil_mcp.tools.registry import register_tool
+
+
+@register_tool
+class ListFoldersTool(BaseTool):
+    """Tool to list all available email folders/mailboxes."""
+
+    name: ClassVar[str] = "list_folders"
+    description: ClassVar[str] = "List all available email folders/mailboxes"
+    input_schema: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    }
+
+    def execute(self, arguments: dict[str, Any]) -> list[TextContent]:
+        """Execute the list_folders tool.
+
+        Args:
+            arguments: Empty dict (no parameters required)
+
+        Returns:
+            List containing a single TextContent with folder names
+        """
+        folders = self.service.list_folders()
+        result = "\n".join(f"- {f.name}" for f in folders)
+        return [TextContent(type="text", text=result or "No folders found.")]

--- a/src/read_no_evil_mcp/tools/registry.py
+++ b/src/read_no_evil_mcp/tools/registry.py
@@ -1,0 +1,62 @@
+"""Tool registry for decorator-based registration."""
+
+from typing import Any
+
+from mcp.types import TextContent, Tool
+
+from read_no_evil_mcp.service import EmailService
+from read_no_evil_mcp.tools.base import BaseTool
+
+# Global registry of tool classes
+_tool_registry: dict[str, type[BaseTool]] = {}
+
+
+def register_tool(cls: type[BaseTool]) -> type[BaseTool]:
+    """Decorator to register a tool class in the global registry.
+
+    Usage:
+        @register_tool
+        class MyTool(BaseTool):
+            ...
+    """
+    _tool_registry[cls.name] = cls
+    return cls
+
+
+def get_all_tools() -> list[Tool]:
+    """Get MCP Tool definitions for all registered tools."""
+    return [
+        Tool(
+            name=tool_cls.name,
+            description=tool_cls.description,
+            inputSchema=tool_cls.input_schema,
+        )
+        for tool_cls in _tool_registry.values()
+    ]
+
+
+def execute_tool(name: str, arguments: dict[str, Any], service: EmailService) -> list[TextContent]:
+    """Execute a registered tool by name.
+
+    Args:
+        name: The tool name to execute
+        arguments: The arguments to pass to the tool
+        service: The EmailService instance to use
+
+    Returns:
+        List of TextContent results
+
+    Raises:
+        KeyError: If the tool is not found
+    """
+    if name not in _tool_registry:
+        raise KeyError(f"Unknown tool: {name}")
+
+    tool_cls = _tool_registry[name]
+    tool = tool_cls(service)
+    return tool.execute(arguments)
+
+
+def get_tool_names() -> list[str]:
+    """Get list of all registered tool names."""
+    return list(_tool_registry.keys())


### PR DESCRIPTION
## Summary

- Extract inline tool definitions from `server.py` into a modular `tools/` directory
- Add `BaseTool` ABC defining the tool interface (name, description, schema, execute)
- Add `@register_tool` decorator for automatic tool registration
- Create individual tool files: `list_folders.py`, `list_emails.py`, `get_email.py`
- Simplify `server.py` to use `get_all_tools()` and `execute_tool()` from registry

## Test plan

- [x] All 53 existing tests pass
- [x] ruff check passes
- [x] mypy passes on source files
- [x] Tool schemas unchanged (verified by existing tests)
- [x] Tool behavior unchanged (verified by existing tests)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)