### PR TITLE
chore: Use CPU-only llm-guard to reduce dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp",
-    "llm-guard",
+    "llm-guard[onnxruntime]",
     "imap-tools",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
Switches from full `llm-guard` (requires PyTorch ~2-3GB) to the ONNX Runtime variant `llm-guard[onnxruntime]` (~500MB) for lighter installation footprint.

This makes the MCP much more practical for typical server deployments.