### PR TITLE
fix: Detect new files in detection matrix workflow

### DIFF
--- a/.github/workflows/update-detection-matrix.yml
+++ b/.github/workflows/update-detection-matrix.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Check for changes
         id: check
         run: |
-          if git diff --quiet DETECTION_MATRIX.md 2>/dev/null; then
+          git add DETECTION_MATRIX.md
+          if git diff --staged --quiet DETECTION_MATRIX.md; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The previous check used `git diff` which only sees modified files, not new (untracked) ones.

Since DETECTION_MATRIX.md doesn't exist yet, the workflow thought there were no changes.

**Fix:** `git add` first, then `git diff --staged` to catch both new and modified files.