### PR TITLE
ci: Remove paths-ignore to fix auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
 
 jobs:
   test:


### PR DESCRIPTION
**Problem:** `paths-ignore` caused CI to not run for docs-only PRs (like Detection Matrix updates), leaving status checks in 'pending' forever → auto-merge never triggers.

**Solution:** Remove `paths-ignore`. CI now runs for all PRs (~4 min).

**Tradeoff:** Slightly longer CI for docs-only changes, but auto-merge works reliably.