### PR TITLE
ci: Use PAT token to trigger CI on auto-generated PRs

### DIFF
--- a/.github/workflows/update-detection-matrix.yml
+++ b/.github/workflows/update-detection-matrix.yml
@@ -49,7 +49,9 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT instead of GITHUB_TOKEN to trigger CI workflows on the PR
+          # GITHUB_TOKEN cannot trigger workflows (GitHub security measure)
+          token: ${{ secrets.PR_TOKEN }}
           commit-message: "docs: Update detection matrix"
           title: "docs: Update detection matrix"
           body: |
@@ -64,4 +66,4 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
## Problem
Der aktuelle PR #40 hat keine CI-Checks, weil `GITHUB_TOKEN` keine Workflows triggern kann auf PRs die es selbst erstellt hat. Das ist eine GitHub-Sicherheitsmaßnahme gegen rekursive Loops.

## Lösung
Nutze einen Personal Access Token (PAT) statt `GITHUB_TOKEN` für:
- PR-Erstellung via `peter-evans/create-pull-request`
- Auto-merge via `gh pr merge`

## Setup erforderlich
Nach dem Merge diesen Secret hinzufügen:

**Secret Name:** `PR_TOKEN`

**Erforderliche Permissions (Fine-grained PAT):**
- `contents: write`
- `pull-requests: write`

**Erstellen unter:** https://github.com/settings/tokens?type=beta

---
Sobald der Token hinzugefügt ist, wird der nächste Push auf `main` einen Detection Matrix PR erstellen, der automatisch CI-Tests triggert.