### PR TITLE
fix: Prevent infinite loop in detection matrix workflow

### DIFF
--- a/.github/workflows/update-detection-matrix.yml
+++ b/.github/workflows/update-detection-matrix.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update-matrix:
     runs-on: ubuntu-latest
+    # Skip if commit was made by github-actions[bot] to prevent infinite loops
+    # when the auto-generated detection matrix PR is merged
+    if: github.event_name == 'workflow_dispatch' || github.event.head_commit.author.name != 'github-actions[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

When the auto-generated detection matrix PR gets merged to main, it triggers another workflow run, creating an infinite loop of PRs.

## Solution

Add a job-level condition to skip the workflow if the commit was made by `github-actions[bot]`. The condition:
- **Allows** manual `workflow_dispatch` triggers (always runs)
- **Allows** commits from human contributors (runs normally)
- **Skips** commits from `github-actions[bot]` (prevents the loop)

## Changes

- Added `if:` condition at the job level in `.github/workflows/update-detection-matrix.yml`

Closes #49