### PR TITLE
fix: prevent infinite loop by checking commit message pattern

### DIFF
--- a/.github/workflows/update-detection-matrix.yml
+++ b/.github/workflows/update-detection-matrix.yml
@@ -8,9 +8,11 @@ on:
 jobs:
   update-matrix:
     runs-on: ubuntu-latest
-    # Skip if commit was made by github-actions[bot] to prevent infinite loops
-    # when the auto-generated detection matrix PR is merged
-    if: github.event_name == 'workflow_dispatch' || github.event.head_commit.author.name != 'github-actions[bot]'
+    # Skip if commit message matches auto-generated pattern to prevent infinite loops.
+    # Note: Checking author.name doesn't work because squash-merge uses the merger's name.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message, 'docs: Update detection matrix')
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

PR #51's fix doesn't work because when a PR is squash-merged, the commit author becomes the person who clicked "Merge" (e.g., "Daniel Kunigk"), not "github-actions[bot]".

This is causing the detection matrix workflow to run in an infinite loop, creating new PRs every few minutes.

## Solution

Check the commit message pattern instead of the author name. The auto-generated commits always have the message `docs: Update detection matrix`, so we can reliably detect and skip them.

## Changes

```yaml
# Before (broken)
if: github.event_name == 'workflow_dispatch' || github.event.head_commit.author.name != 'github-actions[bot]'

# After (fixed)
if: >
  github.event_name == 'workflow_dispatch' ||
  !startsWith(github.event.head_commit.message, 'docs: Update detection matrix')
```

Closes #49