### PR TITLE
feat: Add delete_email MCP tool

### DIFF
--- a/src/read_no_evil_mcp/email/connectors/base.py
+++ b/src/read_no_evil_mcp/email/connectors/base.py
@@ -64,6 +64,19 @@ class BaseConnector(ABC):
         """
         ...
 
+    @abstractmethod
+    def delete_email(self, folder: str, uid: int) -> bool:
+        """Delete an email by UID.
+
+        Args:
+            folder: Folder/mailbox containing the email
+            uid: Unique identifier of the email
+
+        Returns:
+            True if email was deleted successfully, False otherwise.
+        """
+        ...
+
     def __enter__(self) -> "BaseConnector":
         """Context manager entry - connect to server."""
         self.connect()

--- a/src/read_no_evil_mcp/email/connectors/imap.py
+++ b/src/read_no_evil_mcp/email/connectors/imap.py
@@ -161,3 +161,23 @@ class IMAPConnector(BaseConnector):
             )
 
         return None
+
+    def delete_email(self, folder: str, uid: int) -> bool:
+        """Delete an email by UID.
+
+        Args:
+            folder: IMAP folder containing the email
+            uid: Unique identifier of the email
+
+        Returns:
+            True if email was deleted successfully, False otherwise.
+        """
+        if not self._mailbox:
+            raise RuntimeError("Not connected. Call connect() first.")
+
+        self._mailbox.folder.set(folder)
+
+        # Use imap-tools delete method to mark email as deleted
+        self._mailbox.delete(str(uid))
+
+        return True

--- a/src/read_no_evil_mcp/mailbox.py
+++ b/src/read_no_evil_mcp/mailbox.py
@@ -222,3 +222,22 @@ class SecureMailbox:
             raise PromptInjectionError(scan_result, uid, folder)
 
         return email
+
+    def delete_email(self, folder: str, uid: int) -> bool:
+        """Delete an email by UID.
+
+        Args:
+            folder: Folder containing the email
+            uid: Unique identifier of the email
+
+        Returns:
+            True if email was deleted successfully, False otherwise.
+
+        Raises:
+            PermissionDeniedError: If delete access is denied or folder is not allowed.
+        """
+        if not self._permissions.delete:
+            raise PermissionDeniedError("Delete access denied for this account")
+        self._require_folder(folder)
+
+        return self._connector.delete_email(folder, uid)

--- a/src/read_no_evil_mcp/tools/__init__.py
+++ b/src/read_no_evil_mcp/tools/__init__.py
@@ -4,6 +4,7 @@ This module re-exports the shared FastMCP instance and imports all tools
 to trigger their registration.
 """
 
+from read_no_evil_mcp.tools import delete_email as _delete_email  # noqa: F401
 from read_no_evil_mcp.tools import get_email as _get_email  # noqa: F401
 from read_no_evil_mcp.tools import list_accounts as _list_accounts  # noqa: F401
 from read_no_evil_mcp.tools import list_emails as _list_emails  # noqa: F401

--- a/src/read_no_evil_mcp/tools/delete_email.py
+++ b/src/read_no_evil_mcp/tools/delete_email.py
@@ -1,0 +1,24 @@
+"""Delete email MCP tool."""
+
+from read_no_evil_mcp.exceptions import PermissionDeniedError
+from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._service import create_securemailbox
+
+
+@mcp.tool
+def delete_email(account: str, folder: str, uid: int) -> str:
+    """Delete an email by UID.
+
+    Args:
+        account: Account ID to use (e.g., "work", "personal").
+        folder: Folder containing the email.
+        uid: Unique identifier of the email.
+    """
+    try:
+        with create_securemailbox(account) as mailbox:
+            success = mailbox.delete_email(folder, uid)
+            if success:
+                return f"Successfully deleted email {folder}/{uid}"
+            return f"Failed to delete email {folder}/{uid}"
+    except PermissionDeniedError as e:
+        return f"Permission denied: {e}"

--- a/tests/email/connectors/test_imap.py
+++ b/tests/email/connectors/test_imap.py
@@ -191,3 +191,36 @@ class TestIMAPConnector:
         connector = IMAPConnector(config)
         with pytest.raises(RuntimeError, match="Not connected"):
             connector.get_email("INBOX", 123)
+
+    @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
+    def test_delete_email(self, mock_mailbox_class: MagicMock, config: IMAPConfig) -> None:
+        mock_mailbox = MagicMock()
+        mock_mailbox_class.return_value = mock_mailbox
+
+        connector = IMAPConnector(config)
+        connector.connect()
+        result = connector.delete_email("INBOX", 123)
+
+        assert result is True
+        mock_mailbox.folder.set.assert_called_with("INBOX")
+        mock_mailbox.delete.assert_called_once_with("123")
+
+    @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
+    def test_delete_email_different_folder(
+        self, mock_mailbox_class: MagicMock, config: IMAPConfig
+    ) -> None:
+        mock_mailbox = MagicMock()
+        mock_mailbox_class.return_value = mock_mailbox
+
+        connector = IMAPConnector(config)
+        connector.connect()
+        result = connector.delete_email("Sent", 456)
+
+        assert result is True
+        mock_mailbox.folder.set.assert_called_with("Sent")
+        mock_mailbox.delete.assert_called_once_with("456")
+
+    def test_delete_email_not_connected(self, config: IMAPConfig) -> None:
+        connector = IMAPConnector(config)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            connector.delete_email("INBOX", 123)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,4 +11,10 @@ class TestMCPSetup:
     def test_tools_registered(self) -> None:
         """Test that all expected tools are registered."""
         tool_names = set(mcp._tool_manager._tools.keys())
-        assert tool_names == {"list_folders", "list_emails", "get_email", "list_accounts"}
+        assert tool_names == {
+            "delete_email",
+            "get_email",
+            "list_accounts",
+            "list_emails",
+            "list_folders",
+        }

--- a/tests/tools/test_delete_email.py
+++ b/tests/tools/test_delete_email.py
@@ -1,0 +1,109 @@
+"""Tests for delete_email tool."""
+
+from unittest.mock import MagicMock, patch
+
+from read_no_evil_mcp.exceptions import PermissionDeniedError
+from read_no_evil_mcp.tools.delete_email import delete_email
+
+
+class TestDeleteEmail:
+    def test_successfully_deletes_email(self) -> None:
+        """Test delete_email tool returns success message."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.return_value = True
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            result = delete_email.fn(account="work", folder="INBOX", uid=123)
+
+        assert "Successfully deleted" in result
+        assert "INBOX/123" in result
+        mock_mailbox.delete_email.assert_called_once_with("INBOX", 123)
+
+    def test_delete_fails(self) -> None:
+        """Test delete_email returns failure message when deletion fails."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.return_value = False
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            result = delete_email.fn(account="work", folder="INBOX", uid=123)
+
+        assert "Failed to delete" in result
+        assert "INBOX/123" in result
+
+    def test_passes_account_to_create_securemailbox(self) -> None:
+        """Test delete_email passes account to create_securemailbox."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.return_value = True
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ) as mock_create:
+            delete_email.fn(account="personal", folder="INBOX", uid=1)
+
+        mock_create.assert_called_once_with("personal")
+
+    def test_permission_denied_delete(self) -> None:
+        """Test delete_email returns error when delete is denied."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.side_effect = PermissionDeniedError(
+            "Delete access denied for this account"
+        )
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            result = delete_email.fn(account="restricted", folder="INBOX", uid=1)
+
+        assert "Permission denied" in result
+        assert "Delete access denied" in result
+
+    def test_permission_denied_folder(self) -> None:
+        """Test delete_email returns error when folder access is denied."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.side_effect = PermissionDeniedError(
+            "Access to folder 'Secret' denied"
+        )
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            result = delete_email.fn(account="restricted", folder="Secret", uid=1)
+
+        assert "Permission denied" in result
+        assert "folder 'Secret' denied" in result
+
+    def test_different_folder(self) -> None:
+        """Test delete_email works with different folders."""
+        mock_mailbox = MagicMock()
+        mock_mailbox.delete_email.return_value = True
+        mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
+        mock_mailbox.__exit__ = MagicMock(return_value=None)
+
+        with patch(
+            "read_no_evil_mcp.tools.delete_email.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            result = delete_email.fn(account="work", folder="Sent", uid=456)
+
+        assert "Successfully deleted" in result
+        assert "Sent/456" in result
+        mock_mailbox.delete_email.assert_called_once_with("Sent", 456)


### PR DESCRIPTION
Adds delete_email tool with permission checks.

## Changes
- Added delete_email method to BaseConnector and IMAPConnector
- Added delete method to SecureMailbox with permission checks
- Created delete_email MCP tool
- Added tests