### PR TITLE
docs: Add ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,24 @@
+# Roadmap
+
+## v0.2.0 (Current)
+- ✅ Multi-account support with per-account permissions
+- ✅ Prompt injection detection (ML-based)
+- ✅ Read emails with folder support
+- ✅ Move emails between folders
+- ✅ Send emails (plain text, cc, reply-to)
+- ✅ Configurable from_address/from_name
+
+## v0.3.0 (Planned)
+- [ ] **Attachment support for send_email** ([#72](https://github.com/thekie/read-no-evil-mcp/issues/72))
+  - Support file attachments (bytes or path)
+  - Configurable size limits
+  - MIME type validation
+- [ ] HTML email support
+- [ ] Email templates
+
+## Future Ideas
+- OAuth2 authentication (Gmail, Outlook)
+- Calendar integration
+- Contact management
+- Email scheduling
+- Read receipts


### PR DESCRIPTION
Adds a roadmap documenting:

**v0.2.0 (Current)**
- All shipped features (multi-account, detection, send_email, etc.)

**v0.3.0 (Planned)**
- Attachment support (#72)
- HTML email support
- Email templates

**Future Ideas**
- OAuth2, calendar, contacts, scheduling

Related: #72