### PR TITLE
docs: Update README for v0.2 features and SMTP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,17 +262,17 @@ We maintain a comprehensive test suite with **80+ attack payloads** across 7 cat
 - [x] MCP server with list/read tools
 - [x] Comprehensive test suite
 
-### v0.2 (Current)
+### v0.2 (Current) ✅
 - [x] Multi-account support
 - [x] YAML-based configuration
 - [x] Rights management (per-account permissions)
 - [x] Delete emails
 - [x] Send emails (SMTP)
 - [x] Move emails between folders
-- [ ] Configurable sensitivity levels
 
 ### v0.3 (Future)
 - [ ] Attachment support for send_email ([#72](https://github.com/thekie/read-no-evil-mcp/issues/72))
+- [ ] Configurable sensitivity levels
 - [ ] Attachment scanning
 - [ ] Docker image
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "read-no-evil-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "A secure email gateway MCP server that protects AI agents from prompt injection attacks in emails"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Updates README documentation for v0.2 release:

**Roadmap updates:**
- ✅ Check off implemented v0.2 features (delete, send, move emails)
- 📋 Add attachment support to v0.3 roadmap

**Permissions section:**
- Rename `mark_spam` → `move` to match current implementation
- Update permission descriptions

**New section: Sending Emails (SMTP)**
- Document SMTP configuration (`smtp_host`, `smtp_port`, `smtp_ssl`)
- Document sender identity (`from_address`, `from_name`)
- List supported send_email features
- Note attachment support planned for v0.3

Related: #72