### PR TITLE
ci: Add release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      
+      - name: Install build dependencies
+        run: pip install build
+      
+      - name: Build package
+        run: python -m build
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/read-no-evil-mcp
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/read-no-evil-mcp
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds automated release workflow that publishes to PyPI when a GitHub release is created.

## Workflow

1. **Build** — Creates wheel and sdist
2. **TestPyPI** — Publishes to test.pypi.org first (validation)
3. **PyPI** — Publishes to pypi.org

## Features

- Uses **trusted publishing** (OIDC) — no API tokens needed in secrets
- Separate environments for testpypi/pypi (can add approvers if desired)
- Artifacts uploaded for inspection

## Setup Required

Before the first release:

### 1. Create GitHub Environments
Go to repo Settings → Environments → New environment:
- `testpypi`
- `pypi`

### 2. Configure Trusted Publisher on PyPI

**test.pypi.org:**
1. Go to https://test.pypi.org/manage/account/publishing/
2. Add new pending publisher:
   - Owner: `thekie`
   - Repository: `read-no-evil-mcp`
   - Workflow: `release.yml`
   - Environment: `testpypi`

**pypi.org:**
1. Go to https://pypi.org/manage/account/publishing/
2. Add new pending publisher:
   - Owner: `thekie`
   - Repository: `read-no-evil-mcp`
   - Workflow: `release.yml`
   - Environment: `pypi`

## Release Process

After setup, releasing is simple:
1. Create GitHub Release with tag `v0.2.0`
2. Workflow runs automatically
3. Package available on PyPI! 🎉