### PR TITLE
docs: remove AI slop from docs and docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in read-no-evil-mcp! This guide covers everything you need to get started.
+Development setup, testing, and PR workflow for read-no-evil-mcp.
 
 ## Development Setup
 

--- a/DETECTION_MATRIX.md
+++ b/DETECTION_MATRIX.md
@@ -19,7 +19,7 @@ See a ❌ that you think should be detected? Here's how to help:
 2. If not, open an issue describing the attack vector
 3. Or submit a PR improving detection!
 
-Want to add new test cases? Just add entries to the YAML files in
+To add new test cases, add entries to the YAML files in
 `tests/integration/prompt_injection/payloads/`
 
 ---

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ The AI reads this, follows the hidden instruction, and your data is compromised.
 
 ## Features
 
-- 🛡️ **Prompt Injection Detection** — ML-powered scanning using [ProtectAI's DeBERTa model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2)
-- 🔐 **Per-Account Permissions** — Fine-grained access control (read-only by default, restrict folders, control delete/send)
-- 📧 **Multi-Account Support** — Configure multiple IMAP accounts with different permissions each
-- 🔌 **MCP Integration** — Exposes email functionality via [Model Context Protocol](https://modelcontextprotocol.io/)
-- 🏠 **Local Inference** — Model runs on your machine, no data sent to external APIs
-- 🪶 **Lightweight** — CPU-only PyTorch (~200MB) for fast, efficient inference
+- 🛡️ **Prompt Injection Detection** — Scans emails using [ProtectAI's DeBERTa model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2)
+- 🔐 **Per-Account Permissions** — Read-only by default, restrict folders, control delete/send per account
+- 📧 **Multi-Account Support** — Configure multiple IMAP accounts with different permissions
+- 🔌 **MCP Integration** — Exposes email tools via [Model Context Protocol](https://modelcontextprotocol.io/)
+- 🏠 **Local** — Model runs on your machine, no data sent to external APIs
+- 🪶 **CPU-only PyTorch** (~200MB) — No GPU required
 
 ## Quick Start
 
@@ -85,7 +85,7 @@ export RNOE_ACCOUNT_GMAIL_PASSWORD="your-app-password"
 }
 ```
 
-5. **Ask your AI to check your email** — it will only see safe content!
+5. **Ask your AI to check your email** — injected content is blocked before it reaches the agent.
 
 ## Installation
 
@@ -194,7 +194,7 @@ accounts:
 
 ### Access Rules
 
-Control how AI agents interact with emails based on sender and subject patterns. Configure trust levels to streamline workflows for known senders while adding friction for unknown or potentially risky emails.
+Filter emails by sender and subject patterns. Assign trust levels so known senders pass through directly while unknown senders require confirmation.
 
 ```yaml
 accounts:
@@ -334,7 +334,7 @@ See **[DETECTION_MATRIX.md](DETECTION_MATRIX.md)** for what's detected and what'
 | Hidden text | Zero-width chars, HTML comments | 🔬 Testing |
 | Semantic attacks | Roleplay, fake authority | 🔬 Testing |
 
-We maintain a comprehensive test suite with **80+ attack payloads** across 7 categories.
+The test suite includes **80+ attack payloads** across 7 categories.
 
 ## Roadmap
 
@@ -366,7 +366,7 @@ We maintain a comprehensive test suite with **80+ attack payloads** across 7 cat
 
 ## Contributing
 
-We welcome contributions! See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide (dev setup, testing, PR workflow).
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup, testing, and PR workflow.
 
 **Quick ways to help:**
 

--- a/src/read_no_evil_mcp/accounts/config.py
+++ b/src/read_no_evil_mcp/accounts/config.py
@@ -160,20 +160,5 @@ class IMAPAccountConfig(BaseAccountConfig):
     )
 
 
-# Future connectors will follow the same pattern as IMAPAccountConfig:
-# - Inherit from BaseAccountConfig
-# - Add a `type` field with Literal["connector_name"]
-# - Add connector-specific fields
-# Examples: GmailAccountConfig (type="gmail"), MSGraphAccountConfig (type="msgraph")
-
-# Discriminated union - Pydantic picks the right type based on "type" field.
-# When adding new connectors, convert AccountConfig to a discriminated union:
-#
-#     from typing import Annotated, Union
-#     AccountConfig = Annotated[
-#         Union[IMAPAccountConfig, GmailAccountConfig, MSGraphAccountConfig],
-#         Field(discriminator="type"),
-#     ]
-#
-# For now with single type, use simple alias (discriminator activates with Union).
+# When adding new connector types, convert this to a discriminated union on "type".
 AccountConfig = IMAPAccountConfig

--- a/src/read_no_evil_mcp/mailbox.py
+++ b/src/read_no_evil_mcp/mailbox.py
@@ -33,14 +33,10 @@ class PromptInjectionError(Exception):
 
 
 class SecureMailbox:
-    """Secure email access with prompt injection protection and permission enforcement.
+    """Scans email content for prompt injection before returning it to the agent.
 
-    Wraps a BaseConnector and scans email content before returning it.
-    Blocks emails that contain detected prompt injection attacks.
-    Enforces account permissions on all operations.
-
-    Returns SecureEmail and SecureEmailSummary objects that include
-    access level and prompt information based on account access rules.
+    Blocks emails with detected attacks, enforces per-account permissions,
+    and annotates results with access level and prompt from access rules.
     """
 
     def __init__(

--- a/src/read_no_evil_mcp/protection/service.py
+++ b/src/read_no_evil_mcp/protection/service.py
@@ -38,11 +38,7 @@ def strip_html_tags(html: str) -> str:
 
 
 class ProtectionService:
-    """Orchestrates content scanning for prompt injection attacks.
-
-    Delegates to HeuristicScanner which uses ProtectAI's DeBERTa model
-    for ML-based prompt injection detection.
-    """
+    """Scans content for prompt injection using HeuristicScanner (ProtectAI DeBERTa model)."""
 
     def __init__(self, scanner: HeuristicScanner | None = None) -> None:
         """Initialize the protection service.

--- a/src/read_no_evil_mcp/tools/send_email.py
+++ b/src/read_no_evil_mcp/tools/send_email.py
@@ -82,7 +82,6 @@ def send_email(
             - path: File path to read from (required if content not provided)
     """
     try:
-        # Cast is safe: FastMCP validates JSON input to AttachmentInput models
         parsed_attachments = _parse_attachments(
             cast(list[AttachmentInput | dict[str, Any]] | None, attachments)
         )


### PR DESCRIPTION
## Summary

- **README.md**: Replace marketing buzzwords ("ML-powered scanning", "streamline workflows", "adding friction", "Lightweight", "fast, efficient inference") with direct language. Tone down exclamation-style marketing copy.
- **CONTRIBUTING.md**: Replace boilerplate opener ("covers everything you need to get started") with a direct description.
- **DETECTION_MATRIX.md**: Remove filler word ("Just add entries" → "add entries").
- **mailbox.py**: Tighten `SecureMailbox` docstring — remove "Wraps a BaseConnector" and repetitive bullet points.
- **protection/service.py**: Collapse verbose `ProtectionService` docstring ("Orchestrates content scanning... Delegates to...") into one line.
- **accounts/config.py**: Replace 15-line speculative comment block about future connectors with a single line.
- **tools/send_email.py**: Remove obvious comment explaining why a cast is safe.

Net: **-24 lines**, no behavior changes. All tests pass.

## Test plan

- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes
- [x] `uv run pytest` — 420 passed, 70 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)