### PR TITLE
fix: validate MCP tool parameters before use

### DIFF
--- a/src/read_no_evil_mcp/tools/delete_email.py
+++ b/src/read_no_evil_mcp/tools/delete_email.py
@@ -14,6 +14,11 @@ def delete_email(account: str, folder: str, uid: int) -> str:
         folder: Folder containing the email.
         uid: Unique identifier of the email.
     """
+    if uid < 1:
+        return "Invalid parameter: uid must be a positive integer"
+    if not folder or not folder.strip():
+        return "Invalid parameter: folder must not be empty"
+
     try:
         with create_securemailbox(account) as mailbox:
             success = mailbox.delete_email(folder, uid)

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -22,6 +22,11 @@ def get_email(account: str, folder: str, uid: int) -> str:
         folder: Folder containing the email.
         uid: Unique identifier of the email.
     """
+    if uid < 1:
+        return "Invalid parameter: uid must be a positive integer"
+    if not folder or not folder.strip():
+        return "Invalid parameter: folder must not be empty"
+
     try:
         with create_securemailbox(account) as mailbox:
             try:

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -30,6 +30,13 @@ def list_emails(
         days_back: Number of days to look back (default: 7).
         limit: Maximum number of emails to return.
     """
+    if days_back < 1:
+        return "Invalid parameter: days_back must be a positive integer"
+    if not folder or not folder.strip():
+        return "Invalid parameter: folder must not be empty"
+    if limit is not None and limit < 1:
+        return "Invalid parameter: limit must be a positive integer"
+
     try:
         with create_securemailbox(account) as mailbox:
             secure_emails = mailbox.fetch_emails(

--- a/src/read_no_evil_mcp/tools/models.py
+++ b/src/read_no_evil_mcp/tools/models.py
@@ -1,6 +1,8 @@
 """Pydantic models for MCP tools."""
 
-from pydantic import BaseModel
+import base64
+
+from pydantic import BaseModel, field_validator
 
 __all__ = ["AttachmentInput"]
 
@@ -15,3 +17,24 @@ class AttachmentInput(BaseModel):
     content: str | None = None  # base64-encoded bytes
     mime_type: str = "application/octet-stream"
     path: str | None = None
+
+    @field_validator("filename")
+    @classmethod
+    def validate_filename(cls, v: str) -> str:
+        if not v:
+            raise ValueError("filename must not be empty")
+        if "/" in v or "\\" in v:
+            raise ValueError("filename must not contain path separators")
+        if v.startswith("."):
+            raise ValueError("filename must not start with '.'")
+        return v
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: str | None) -> str | None:
+        if v is not None:
+            try:
+                base64.b64decode(v)
+            except Exception as err:
+                raise ValueError("content must be valid base64") from err
+        return v

--- a/src/read_no_evil_mcp/tools/move_email.py
+++ b/src/read_no_evil_mcp/tools/move_email.py
@@ -15,6 +15,13 @@ def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
         uid: Unique identifier of the email.
         target_folder: Destination folder to move the email to.
     """
+    if uid < 1:
+        return "Invalid parameter: uid must be a positive integer"
+    if not folder or not folder.strip():
+        return "Invalid parameter: folder must not be empty"
+    if not target_folder or not target_folder.strip():
+        return "Invalid parameter: target_folder must not be empty"
+
     try:
         with create_securemailbox(account) as mailbox:
             success = mailbox.move_email(folder, uid, target_folder)

--- a/tests/tools/test_delete_email.py
+++ b/tests/tools/test_delete_email.py
@@ -107,3 +107,23 @@ class TestDeleteEmail:
         assert "Successfully deleted" in result
         assert "Sent/456" in result
         mock_mailbox.delete_email.assert_called_once_with("Sent", 456)
+
+
+class TestDeleteEmailValidation:
+    def test_uid_zero_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="INBOX", uid=0)
+        assert "Invalid parameter" in result
+        assert "uid" in result
+
+    def test_uid_negative_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="INBOX", uid=-5)
+        assert "Invalid parameter" in result
+
+    def test_empty_folder_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="", uid=1)
+        assert "Invalid parameter" in result
+        assert "folder" in result
+
+    def test_whitespace_folder_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="  ", uid=1)
+        assert "Invalid parameter" in result

--- a/tests/tools/test_get_email.py
+++ b/tests/tools/test_get_email.py
@@ -283,3 +283,25 @@ class TestGetEmail:
             result = get_email.fn(account="work", folder="INBOX", uid=123)
 
         assert "Custom trusted read prompt here" in result
+
+
+class TestGetEmailValidation:
+    def test_uid_zero_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="INBOX", uid=0)
+        assert "Invalid parameter" in result
+        assert "uid" in result
+
+    def test_uid_negative_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="INBOX", uid=-1)
+        assert "Invalid parameter" in result
+        assert "uid" in result
+
+    def test_empty_folder_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="", uid=1)
+        assert "Invalid parameter" in result
+        assert "folder" in result
+
+    def test_whitespace_folder_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="   ", uid=1)
+        assert "Invalid parameter" in result
+        assert "folder" in result

--- a/tests/tools/test_list_emails.py
+++ b/tests/tools/test_list_emails.py
@@ -266,3 +266,32 @@ class TestListEmails:
             result = list_emails.fn(account="work")
 
         assert "[ASK]" in result
+
+
+class TestListEmailsValidation:
+    def test_days_back_zero_rejected(self) -> None:
+        result = list_emails.fn(account="work", days_back=0)
+        assert "Invalid parameter" in result
+        assert "days_back" in result
+
+    def test_days_back_negative_rejected(self) -> None:
+        result = list_emails.fn(account="work", days_back=-1)
+        assert "Invalid parameter" in result
+
+    def test_empty_folder_rejected(self) -> None:
+        result = list_emails.fn(account="work", folder="")
+        assert "Invalid parameter" in result
+        assert "folder" in result
+
+    def test_whitespace_folder_rejected(self) -> None:
+        result = list_emails.fn(account="work", folder="  ")
+        assert "Invalid parameter" in result
+
+    def test_limit_zero_rejected(self) -> None:
+        result = list_emails.fn(account="work", limit=0)
+        assert "Invalid parameter" in result
+        assert "limit" in result
+
+    def test_limit_negative_rejected(self) -> None:
+        result = list_emails.fn(account="work", limit=-3)
+        assert "Invalid parameter" in result

--- a/tests/tools/test_move_email.py
+++ b/tests/tools/test_move_email.py
@@ -146,3 +146,24 @@ class TestMoveEmail:
 
         assert "Error" in result
         assert "Connection lost" in result
+
+
+class TestMoveEmailValidation:
+    def test_uid_zero_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="INBOX", uid=0, target_folder="Archive")
+        assert "Invalid parameter" in result
+        assert "uid" in result
+
+    def test_empty_folder_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="", uid=1, target_folder="Archive")
+        assert "Invalid parameter" in result
+        assert "folder" in result
+
+    def test_empty_target_folder_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="INBOX", uid=1, target_folder="")
+        assert "Invalid parameter" in result
+        assert "target_folder" in result
+
+    def test_whitespace_target_folder_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="INBOX", uid=1, target_folder="   ")
+        assert "Invalid parameter" in result

--- a/tests/tools/test_send_email.py
+++ b/tests/tools/test_send_email.py
@@ -488,3 +488,59 @@ class TestParseAttachments:
                     }
                 ]
             )
+
+
+class TestAttachmentInputValidation:
+    """Tests for AttachmentInput field validators."""
+
+    def test_filename_with_slash_rejected(self) -> None:
+        import pytest
+
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        with pytest.raises(ValueError, match="path separators"):
+            AttachmentInput(filename="../etc/passwd", content=base64.b64encode(b"x").decode())
+
+    def test_filename_with_backslash_rejected(self) -> None:
+        import pytest
+
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        with pytest.raises(ValueError, match="path separators"):
+            AttachmentInput(filename="..\\etc\\passwd", content=base64.b64encode(b"x").decode())
+
+    def test_filename_starting_with_dot_rejected(self) -> None:
+        import pytest
+
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        with pytest.raises(ValueError, match="must not start with"):
+            AttachmentInput(filename=".hidden", content=base64.b64encode(b"x").decode())
+
+    def test_empty_filename_rejected(self) -> None:
+        import pytest
+
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        with pytest.raises(ValueError, match="must not be empty"):
+            AttachmentInput(filename="", content=base64.b64encode(b"x").decode())
+
+    def test_invalid_base64_rejected(self) -> None:
+        import pytest
+
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        with pytest.raises(ValueError, match="valid base64"):
+            AttachmentInput(filename="test.txt", content="not-valid-base64!!!")
+
+    def test_valid_base64_accepted(self) -> None:
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        att = AttachmentInput(filename="test.txt", content=base64.b64encode(b"hello").decode())
+        assert att.content is not None
+
+    def test_none_content_accepted(self) -> None:
+        from read_no_evil_mcp.tools.models import AttachmentInput
+
+        att = AttachmentInput(filename="test.txt", path="/some/path")
+        assert att.content is None


### PR DESCRIPTION
## Summary
- Add input validation to all MCP tool functions (get_email, delete_email, move_email, list_emails) to reject invalid uid, folder, days_back, and limit parameters before any IMAP/SMTP calls
- Add Pydantic field validators to AttachmentInput for filename path traversal prevention and base64 content validation
- Add 25 new unit tests covering all validation paths

## Test plan
- [x] All 94 tool tests pass
- [x] ruff check, ruff format, mypy all pass
- [x] Validation rejects: uid=0, uid<0, empty folder, whitespace folder, days_back=0, limit=0, filenames with path separators or leading dot, invalid base64

Closes #109