### PR TITLE
fix: add consistent error handling across all MCP tools

### DIFF
--- a/src/read_no_evil_mcp/tools/_error_handler.py
+++ b/src/read_no_evil_mcp/tools/_error_handler.py
@@ -1,0 +1,56 @@
+"""Common error handling for MCP tools."""
+
+import logging
+import smtplib
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from imap_tools import ImapToolsError
+
+from read_no_evil_mcp.exceptions import (
+    AccountNotFoundError,
+    ConfigError,
+    CredentialNotFoundError,
+    PermissionDeniedError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def handle_tool_errors(func: Callable[..., str]) -> Callable[..., str]:
+    """Wrap an MCP tool function to catch connector-level exceptions."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> str:
+        try:
+            return func(*args, **kwargs)
+        except PermissionDeniedError as e:
+            return f"Permission denied: {e}"
+        except AccountNotFoundError as e:
+            return f"Account not found: {e.account_id}"
+        except CredentialNotFoundError as e:
+            return f"Configuration error: {e}"
+        except ConfigError as e:
+            return f"Configuration error: {e}"
+        except ImapToolsError as e:
+            return f"Email server error: {e}"
+        except smtplib.SMTPAuthenticationError:
+            return "Email server authentication failed. Check your credentials."
+        except smtplib.SMTPException as e:
+            return f"Error sending email: {e}"
+        except ValueError as e:
+            return f"Invalid input: {e}"
+        except RuntimeError as e:
+            return f"Error: {e}"
+        except TimeoutError:
+            return "Connection timed out. The email server did not respond."
+        except ConnectionError as e:
+            return f"Could not connect to email server: {e}"
+        except OSError as e:
+            return f"Network error: {e}"
+        except Exception:
+            logger.exception("Unexpected error in tool %s", func.__name__)
+            return "An unexpected error occurred. Check the server logs for details."
+
+    return wrapper

--- a/src/read_no_evil_mcp/tools/delete_email.py
+++ b/src/read_no_evil_mcp/tools/delete_email.py
@@ -1,11 +1,12 @@
 """Delete email MCP tool."""
 
-from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
 
 
 @mcp.tool
+@handle_tool_errors
 def delete_email(account: str, folder: str, uid: int) -> str:
     """Delete an email by UID.
 
@@ -19,11 +20,8 @@ def delete_email(account: str, folder: str, uid: int) -> str:
     if not folder or not folder.strip():
         return "Invalid parameter: folder must not be empty"
 
-    try:
-        with create_securemailbox(account) as mailbox:
-            success = mailbox.delete_email(folder, uid)
-            if success:
-                return f"Successfully deleted email {folder}/{uid}"
-            return f"Failed to delete email {folder}/{uid}"
-    except PermissionDeniedError as e:
-        return f"Permission denied: {e}"
+    with create_securemailbox(account) as mailbox:
+        success = mailbox.delete_email(folder, uid)
+        if success:
+            return f"Successfully deleted email {folder}/{uid}"
+        return f"Failed to delete email {folder}/{uid}"

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -1,9 +1,9 @@
 """Get email MCP tool."""
 
 from read_no_evil_mcp.accounts.config import AccessLevel
-from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.mailbox import PromptInjectionError
 from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
 
 # Mapping of access levels to display names
@@ -14,6 +14,7 @@ ACCESS_DISPLAY: dict[AccessLevel, str] = {
 
 
 @mcp.tool
+@handle_tool_errors
 def get_email(account: str, folder: str, uid: int) -> str:
     """Get full email content by UID.
 
@@ -27,58 +28,55 @@ def get_email(account: str, folder: str, uid: int) -> str:
     if not folder or not folder.strip():
         return "Invalid parameter: folder must not be empty"
 
-    try:
-        with create_securemailbox(account) as mailbox:
-            try:
-                secure_email = mailbox.get_email(folder, uid)
-            except PromptInjectionError as e:
-                patterns = ", ".join(e.scan_result.detected_patterns)
-                return (
-                    f"BLOCKED: Email {folder}/{uid} contains suspected prompt injection.\n"
-                    f"Detected patterns: {patterns}\n"
-                    f"Score: {e.scan_result.score:.2f}\n\n"
-                    "This email has been blocked to protect against prompt injection attacks."
-                )
+    with create_securemailbox(account) as mailbox:
+        try:
+            secure_email = mailbox.get_email(folder, uid)
+        except PromptInjectionError as e:
+            patterns = ", ".join(e.scan_result.detected_patterns)
+            return (
+                f"BLOCKED: Email {folder}/{uid} contains suspected prompt injection.\n"
+                f"Detected patterns: {patterns}\n"
+                f"Score: {e.scan_result.score:.2f}\n\n"
+                "This email has been blocked to protect against prompt injection attacks."
+            )
 
-            if not secure_email:
-                return f"Email not found: {folder}/{uid}"
+        if not secure_email:
+            return f"Email not found: {folder}/{uid}"
 
-            email = secure_email.email
-            lines = [
-                f"Subject: {email.subject}",
-                f"From: {email.sender}",
-                f"To: {', '.join(str(addr) for addr in email.to)}",
-                f"Date: {email.date.strftime('%Y-%m-%d %H:%M:%S')}",
-                f"Status: {'Read' if email.is_seen else 'Unread'}",
-            ]
+        email = secure_email.email
+        lines = [
+            f"Subject: {email.subject}",
+            f"From: {email.sender}",
+            f"To: {', '.join(str(addr) for addr in email.to)}",
+            f"Date: {email.date.strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Status: {'Read' if email.is_seen else 'Unread'}",
+        ]
 
-            # Add access level for trusted and ask_before_read
-            if secure_email.access_level in ACCESS_DISPLAY:
-                lines.append(f"Access: {ACCESS_DISPLAY[secure_email.access_level]}")
-                # Add prompt if present in the enriched model
-                if secure_email.prompt:
-                    lines.append(f"-> {secure_email.prompt}")
+        # Add access level for trusted and ask_before_read
+        if secure_email.access_level in ACCESS_DISPLAY:
+            lines.append(f"Access: {ACCESS_DISPLAY[secure_email.access_level]}")
+            # Add prompt if present in the enriched model
+            if secure_email.prompt:
+                lines.append(f"-> {secure_email.prompt}")
 
-            if email.cc:
-                lines.append(f"CC: {', '.join(str(addr) for addr in email.cc)}")
+        if email.cc:
+            lines.append(f"CC: {', '.join(str(addr) for addr in email.cc)}")
 
-            if email.message_id:
-                lines.append(f"Message-ID: {email.message_id}")
+        if email.message_id:
+            lines.append(f"Message-ID: {email.message_id}")
 
-            if email.attachments:
-                att_list = ", ".join(a.filename for a in email.attachments)
-                lines.append(f"Attachments: {att_list}")
+        if email.attachments:
+            att_list = ", ".join(a.filename for a in email.attachments)
+            lines.append(f"Attachments: {att_list}")
 
-            lines.append("")  # Empty line before body
+        lines.append("")  # Empty line before body
 
-            if email.body_plain:
-                lines.append(email.body_plain)
-            elif email.body_html:
-                lines.append("[HTML content - plain text not available]")
-                lines.append(email.body_html)
-            else:
-                lines.append("[No body content]")
+        if email.body_plain:
+            lines.append(email.body_plain)
+        elif email.body_html:
+            lines.append("[HTML content - plain text not available]")
+            lines.append(email.body_html)
+        else:
+            lines.append("[No body content]")
 
-            return "\n".join(lines)
-    except PermissionDeniedError as e:
-        return f"Permission denied: {e}"
+        return "\n".join(lines)

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -3,8 +3,8 @@
 from datetime import timedelta
 
 from read_no_evil_mcp.accounts.config import AccessLevel
-from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
 
 # Mapping of access levels to markers shown in list output
@@ -16,6 +16,7 @@ ACCESS_MARKERS: dict[AccessLevel, str] = {
 
 
 @mcp.tool
+@handle_tool_errors
 def list_emails(
     account: str,
     folder: str = "INBOX",
@@ -37,38 +38,35 @@ def list_emails(
     if limit is not None and limit < 1:
         return "Invalid parameter: limit must be a positive integer"
 
-    try:
-        with create_securemailbox(account) as mailbox:
-            secure_emails = mailbox.fetch_emails(
-                folder,
-                lookback=timedelta(days=days_back),
-                limit=limit,
+    with create_securemailbox(account) as mailbox:
+        secure_emails = mailbox.fetch_emails(
+            folder,
+            lookback=timedelta(days=days_back),
+            limit=limit,
+        )
+
+        if not secure_emails:
+            return "No emails found."
+
+        lines = []
+        for secure_email in secure_emails:
+            email = secure_email.summary
+            date_str = email.date.strftime("%Y-%m-%d %H:%M")
+            attachment_marker = " [+]" if email.has_attachments else ""
+            seen_marker = "" if email.is_seen else " [UNREAD]"
+
+            # Get access marker from the enriched model
+            access_marker = ACCESS_MARKERS.get(secure_email.access_level, "")
+
+            # Build email line
+            email_line = (
+                f"[{email.uid}] {date_str} | {email.sender.address} | "
+                f"{email.subject}{attachment_marker}{seen_marker}{access_marker}"
             )
+            lines.append(email_line)
 
-            if not secure_emails:
-                return "No emails found."
+            # Add prompt if present in the enriched model
+            if secure_email.prompt:
+                lines.append(f"    -> {secure_email.prompt}")
 
-            lines = []
-            for secure_email in secure_emails:
-                email = secure_email.summary
-                date_str = email.date.strftime("%Y-%m-%d %H:%M")
-                attachment_marker = " [+]" if email.has_attachments else ""
-                seen_marker = "" if email.is_seen else " [UNREAD]"
-
-                # Get access marker from the enriched model
-                access_marker = ACCESS_MARKERS.get(secure_email.access_level, "")
-
-                # Build email line
-                email_line = (
-                    f"[{email.uid}] {date_str} | {email.sender.address} | "
-                    f"{email.subject}{attachment_marker}{seen_marker}{access_marker}"
-                )
-                lines.append(email_line)
-
-                # Add prompt if present in the enriched model
-                if secure_email.prompt:
-                    lines.append(f"    -> {secure_email.prompt}")
-
-            return "\n".join(lines)
-    except PermissionDeniedError as e:
-        return f"Permission denied: {e}"
+        return "\n".join(lines)

--- a/src/read_no_evil_mcp/tools/list_folders.py
+++ b/src/read_no_evil_mcp/tools/list_folders.py
@@ -1,22 +1,20 @@
 """List folders MCP tool."""
 
-from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
 
 
 @mcp.tool
+@handle_tool_errors
 def list_folders(account: str) -> str:
     """List all available email folders/mailboxes.
 
     Args:
         account: Account ID to use (e.g., "work", "personal").
     """
-    try:
-        with create_securemailbox(account) as mailbox:
-            folders = mailbox.list_folders()
-            if not folders:
-                return "No folders found."
-            return "\n".join(f"- {f.name}" for f in folders)
-    except PermissionDeniedError as e:
-        return f"Permission denied: {e}"
+    with create_securemailbox(account) as mailbox:
+        folders = mailbox.list_folders()
+        if not folders:
+            return "No folders found."
+        return "\n".join(f"- {f.name}" for f in folders)

--- a/src/read_no_evil_mcp/tools/move_email.py
+++ b/src/read_no_evil_mcp/tools/move_email.py
@@ -1,11 +1,12 @@
 """Move email MCP tool."""
 
-from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.tools._app import mcp
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
 
 
 @mcp.tool
+@handle_tool_errors
 def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
     """Move an email to a target folder.
 
@@ -22,15 +23,10 @@ def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
     if not target_folder or not target_folder.strip():
         return "Invalid parameter: target_folder must not be empty"
 
-    try:
-        with create_securemailbox(account) as mailbox:
-            success = mailbox.move_email(folder, uid, target_folder)
+    with create_securemailbox(account) as mailbox:
+        success = mailbox.move_email(folder, uid, target_folder)
 
-            if success:
-                return f"Email {folder}/{uid} moved to {target_folder}."
-            else:
-                return f"Email not found: {folder}/{uid}"
-    except PermissionDeniedError as e:
-        return f"Permission denied: {e}"
-    except RuntimeError as e:
-        return f"Error: {e}"
+        if success:
+            return f"Email {folder}/{uid} moved to {target_folder}."
+        else:
+            return f"Email not found: {folder}/{uid}"

--- a/tests/tools/test_error_handler.py
+++ b/tests/tools/test_error_handler.py
@@ -1,0 +1,100 @@
+"""Tests for the tool error handler decorator."""
+
+import smtplib
+from unittest.mock import patch
+
+from imap_tools import ImapToolsError
+
+from read_no_evil_mcp.exceptions import (
+    AccountNotFoundError,
+    ConfigError,
+    CredentialNotFoundError,
+    PermissionDeniedError,
+)
+from read_no_evil_mcp.tools._error_handler import handle_tool_errors
+
+
+@handle_tool_errors
+def _dummy_tool(exc: Exception) -> str:
+    raise exc
+
+
+class TestHandleToolErrors:
+    def test_permission_denied(self) -> None:
+        result = _dummy_tool(PermissionDeniedError("Read access denied"))
+        assert "Permission denied" in result
+        assert "Read access denied" in result
+
+    def test_account_not_found(self) -> None:
+        result = _dummy_tool(AccountNotFoundError("nonexistent"))
+        assert "Account not found" in result
+        assert "nonexistent" in result
+
+    def test_credential_not_found(self) -> None:
+        result = _dummy_tool(CredentialNotFoundError("work", "WORK_PASSWORD"))
+        assert "Configuration error" in result
+        assert "WORK_PASSWORD" in result
+
+    def test_config_error(self) -> None:
+        result = _dummy_tool(ConfigError("No accounts configured"))
+        assert "Configuration error" in result
+        assert "No accounts configured" in result
+
+    def test_imap_error(self) -> None:
+        result = _dummy_tool(ImapToolsError("LOGIN failed"))
+        assert "Email server error" in result
+
+    def test_smtp_auth_error(self) -> None:
+        result = _dummy_tool(smtplib.SMTPAuthenticationError(535, b"Authentication failed"))
+        assert "authentication failed" in result.lower()
+
+    def test_smtp_error(self) -> None:
+        result = _dummy_tool(smtplib.SMTPException("Relay denied"))
+        assert "Error sending email" in result
+        assert "Relay denied" in result
+
+    def test_value_error(self) -> None:
+        result = _dummy_tool(ValueError("Attachment 'f.txt' must have 'content'"))
+        assert "Invalid input" in result
+
+    def test_runtime_error(self) -> None:
+        result = _dummy_tool(RuntimeError("Not connected"))
+        assert "Error" in result
+        assert "Not connected" in result
+
+    def test_timeout_error(self) -> None:
+        result = _dummy_tool(TimeoutError())
+        assert "timed out" in result.lower()
+
+    def test_connection_refused(self) -> None:
+        result = _dummy_tool(ConnectionRefusedError("Connection refused"))
+        assert "Could not connect" in result
+
+    def test_connection_reset(self) -> None:
+        result = _dummy_tool(ConnectionResetError("Connection reset"))
+        assert "Could not connect" in result
+
+    def test_os_error(self) -> None:
+        result = _dummy_tool(OSError("Name resolution failed"))
+        assert "Network error" in result
+
+    def test_unexpected_exception_logged(self) -> None:
+        with patch("read_no_evil_mcp.tools._error_handler.logger") as mock_logger:
+            result = _dummy_tool(KeyError("something"))
+
+        assert "unexpected error" in result.lower()
+        mock_logger.exception.assert_called_once()
+
+    def test_successful_call_passes_through(self) -> None:
+        @handle_tool_errors
+        def good_tool() -> str:
+            return "all good"
+
+        assert good_tool() == "all good"
+
+    def test_preserves_function_name(self) -> None:
+        @handle_tool_errors
+        def my_tool() -> str:
+            return ""
+
+        assert my_tool.__name__ == "my_tool"

--- a/tests/tools/test_list_folders.py
+++ b/tests/tools/test_list_folders.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from read_no_evil_mcp.exceptions import PermissionDeniedError
 from read_no_evil_mcp.models import Folder
 from read_no_evil_mcp.tools.list_folders import list_folders
@@ -44,8 +42,8 @@ class TestListFolders:
 
         assert "No folders found" in result
 
-    def test_exit_called_on_exception(self) -> None:
-        """Test that __exit__ is called even when exception occurs."""
+    def test_runtime_error_returns_message(self) -> None:
+        """Test that RuntimeError is caught and returned as user-friendly message."""
         mock_mailbox = MagicMock()
         mock_mailbox.list_folders.side_effect = RuntimeError("Connection error")
         mock_mailbox.__enter__ = MagicMock(return_value=mock_mailbox)
@@ -55,9 +53,10 @@ class TestListFolders:
             "read_no_evil_mcp.tools.list_folders.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            with pytest.raises(RuntimeError):
-                list_folders.fn(account="work")
+            result = list_folders.fn(account="work")
 
+        assert "Error" in result
+        assert "Connection error" in result
         mock_mailbox.__exit__.assert_called_once()
 
     def test_passes_account_to_create_securemailbox(self) -> None:

--- a/tests/tools/test_send_email.py
+++ b/tests/tools/test_send_email.py
@@ -312,7 +312,7 @@ class TestSendEmail:
                 attachments=[{"content": base64.b64encode(b"data").decode()}],
             )
 
-        assert "Invalid attachment" in result
+        assert "Invalid input" in result
         assert "filename" in result
 
     def test_send_email_attachment_missing_content_and_path(self) -> None:
@@ -333,7 +333,7 @@ class TestSendEmail:
                 attachments=[{"filename": "test.txt"}],
             )
 
-        assert "Invalid attachment" in result
+        assert "Invalid input" in result
         assert "content" in result or "path" in result
 
     def test_send_email_with_empty_attachments_list(self) -> None:


### PR DESCRIPTION
## Summary
- Added a `handle_tool_errors` decorator that catches connector-level exceptions (IMAP, SMTP, network, timeout, config) and returns user-friendly error messages instead of raw tracebacks
- Applied the decorator to all 6 MCP tool files, removing duplicated try/except blocks
- Added 16 tests covering all exception branches

## Test plan
- [x] All 384 unit tests pass
- [x] ruff check, ruff format, and mypy all pass
- [x] Verified IMAP errors, SMTP errors, network errors, timeouts, config errors, and unexpected exceptions all return user-friendly messages
- [x] Verified tool-specific handlers (PromptInjectionError in get_email) still work correctly
- [x] Security review: no credential or hostname leakage through error messages
- [x] Architecture review: exception ordering correct for inheritance chains

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)