### PR TITLE
feat: save sent emails to Sent folder via IMAP APPEND

### DIFF
--- a/src/read_no_evil_mcp/accounts/config.py
+++ b/src/read_no_evil_mcp/accounts/config.py
@@ -200,6 +200,10 @@ class IMAPAccountConfig(BaseAccountConfig):
         default=False,
         description="Use SSL instead of STARTTLS for SMTP (default: False)",
     )
+    sent_folder: str | None = Field(
+        default=None,
+        description="IMAP folder for saving sent emails (default: auto-detect)",
+    )
     from_address: str | None = Field(
         default=None,
         min_length=1,

--- a/src/read_no_evil_mcp/accounts/service.py
+++ b/src/read_no_evil_mcp/accounts/service.py
@@ -93,6 +93,7 @@ class AccountService:
                     username=config.username,
                     password=password,
                     ssl=config.smtp_ssl,
+                    sent_folder=config.sent_folder,
                 )
 
             return IMAPConnector(imap_config, smtp_config=smtp_config)

--- a/src/read_no_evil_mcp/email/connectors/config.py
+++ b/src/read_no_evil_mcp/email/connectors/config.py
@@ -21,3 +21,4 @@ class SMTPConfig(BaseModel):
     username: str
     password: SecretStr
     ssl: bool = False  # False = use STARTTLS, True = use SSL
+    sent_folder: str | None = None  # None = auto-detect from IMAP folders

--- a/src/read_no_evil_mcp/email/connectors/smtp.py
+++ b/src/read_no_evil_mcp/email/connectors/smtp.py
@@ -78,7 +78,7 @@ class SMTPConnector:
         cc: list[str] | None = None,
         reply_to: str | None = None,
         attachments: list[OutgoingAttachment] | None = None,
-    ) -> bool:
+    ) -> bytes:
         """Send an email.
 
         Args:
@@ -92,7 +92,7 @@ class SMTPConnector:
             attachments: Optional list of file attachments.
 
         Returns:
-            True if email was sent successfully.
+            The composed message as bytes (for saving to Sent folder).
 
         Raises:
             RuntimeError: If not connected to SMTP server.
@@ -151,5 +151,6 @@ class SMTPConnector:
             recipients.extend(cc)
 
         # Use from_address directly for SMTP envelope (no parsing needed)
-        self._connection.sendmail(from_address, recipients, msg.as_string())
-        return True
+        msg_bytes = msg.as_bytes()
+        self._connection.sendmail(from_address, recipients, msg_bytes)
+        return msg_bytes


### PR DESCRIPTION
## Summary
After sending via SMTP, the message is now saved to the Sent folder using IMAP APPEND.

## Features
- **Auto-detect Sent folder**: Checks common folder names (Sent, INBOX.Sent, [Gmail]/Sent Mail, Gesendet, etc.)
- **Configurable override**: `sent_folder` in SMTPConfig/IMAPAccountConfig for explicit folder name
- **Graceful degradation**: Send succeeds even if IMAP save fails (logged as warning)
- **Full test coverage**: 9 new tests covering all scenarios

## Changes
- `SMTPConnector.send_email()` now returns message bytes instead of bool
- `IMAPConnector.send()` calls `_save_to_sent()` after successful SMTP send
- New `_detect_sent_folder()` method with priority-ordered folder detection
- New `sent_folder` config option in `SMTPConfig` and `IMAPAccountConfig`

## Testing
```bash
pytest tests/email/connectors/test_imap.py -v
# 39 passed
```

Closes #147