### PR TITLE
fix: Sanitize attachment filenames to prevent directory traversal

### DIFF
--- a/src/read_no_evil_mcp/email/connectors/smtp.py
+++ b/src/read_no_evil_mcp/email/connectors/smtp.py
@@ -1,5 +1,6 @@
 """SMTP connector for sending emails using smtplib."""
 
+import os
 import re
 import smtplib
 from email import encoders
@@ -133,10 +134,11 @@ class SMTPConnector:
                 part = MIMEBase(maintype, subtype)
                 part.set_payload(content)
                 encoders.encode_base64(part)
+                safe_filename = os.path.basename(attachment.filename)
                 part.add_header(
                     "Content-Disposition",
                     "attachment",
-                    filename=attachment.filename,
+                    filename=safe_filename,
                 )
                 msg.attach(part)
 


### PR DESCRIPTION
## Summary
- Strip path components from attachment filenames using `os.path.basename()` before setting the `Content-Disposition` header in outgoing emails
- Prevents directory traversal characters (e.g., `../../etc/passwd`) from reaching email recipients' clients

## Test plan
- [x] Test Unix directory traversal (`../../etc/passwd` -> `passwd`)
- [x] Test absolute paths (`/etc/passwd` -> `passwd`)
- [x] Test Windows-style paths (backslash behavior on POSIX)
- [x] Test normal filenames remain unchanged
- [x] All 539 existing tests pass
- [x] Linting, formatting, and type checking pass

Closes #121