### PR TITLE
refactor: Standardize on stdlib logging, remove structlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ Instructions for AI coding assistants working on this project.
 - Use `| None` instead of `Optional[]`
 - External libs without stubs are configured in `pyproject.toml`
 
+### Logging
+- Use stdlib `logging` — no third-party logging libraries
+- Create loggers with `logger = logging.getLogger(__name__)`
+- Use `%`-style formatting: `logger.warning("msg (key=%s)", val)`
+
 ### Imports
 - Use absolute imports: `from read_no_evil_mcp.models import Email`
 - Sort with ruff (isort rules)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "fastmcp",
     "transformers>=4.30",
     "torch",
-    "structlog>=24",
     "imap-tools",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/src/read_no_evil_mcp/protection/heuristic.py
+++ b/src/read_no_evil_mcp/protection/heuristic.py
@@ -4,14 +4,14 @@ Uses the ProtectAI DeBERTa model with PyTorch for ML-based
 prompt injection detection.
 """
 
+import logging
 from typing import Any
 
-import structlog
 from transformers import Pipeline, pipeline
 
 from read_no_evil_mcp.protection.models import ScanResult
 
-logger = structlog.get_logger()
+logger = logging.getLogger(__name__)
 
 # Model for prompt injection detection
 MODEL_ID = "protectai/deberta-v3-base-prompt-injection-v2"
@@ -42,7 +42,7 @@ class HeuristicScanner:
     def _get_classifier(self) -> Any:
         """Lazy load the classifier to avoid slow startup."""
         if self._classifier is None:
-            logger.debug("Loading prompt injection model", model=MODEL_ID)
+            logger.debug("Loading prompt injection model (model=%s)", MODEL_ID)
             self._classifier = pipeline(
                 "text-classification",
                 model=MODEL_ID,
@@ -78,9 +78,9 @@ class HeuristicScanner:
 
         if not is_safe:
             detected_patterns.append("prompt_injection")
-            logger.warning("Detected prompt injection", injection_score=score)
+            logger.warning("Detected prompt injection (injection_score=%s)", score)
         else:
-            logger.debug("No prompt injection detected", highest_score=score)
+            logger.debug("No prompt injection detected (highest_score=%s)", score)
 
         return ScanResult(
             is_safe=is_safe,

--- a/uv.lock
+++ b/uv.lock
@@ -2007,7 +2007,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
-    { name = "structlog" },
     { name = "torch" },
     { name = "transformers" },
 ]
@@ -2032,7 +2031,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "structlog", specifier = ">=24" },
     { name = "torch" },
     { name = "transformers", specifier = ">=4.30" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
@@ -2476,18 +2474,6 @@ wheels = [
 ]
 
 [[package]]
-name = "structlog"
-version = "25.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
-]
-
-[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2504,8 +2490,8 @@ name = "taskgroup"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/8d/e218e0160cc1b692e6e0e5ba34e8865dbb171efeb5fc9a704544b3020605/taskgroup-0.2.2.tar.gz", hash = "sha256:078483ac3e78f2e3f973e2edbf6941374fbea81b9c5d0a96f51d297717f4752d", size = 11504, upload-time = "2025-01-03T09:24:13.761Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Replace `structlog` with stdlib `logging` in `protection/heuristic.py` to match existing patterns in `_error_handler.py` and `imap.py`
- Remove `structlog` dependency from `pyproject.toml`
- Document logging convention in `CLAUDE.md`

Closes #158