### PR TITLE
fix: Call expunge after delete in IMAPConnector

### DIFF
--- a/src/read_no_evil_mcp/email/connectors/imap.py
+++ b/src/read_no_evil_mcp/email/connectors/imap.py
@@ -236,8 +236,8 @@ class IMAPConnector(BaseConnector):
 
         self._mailbox.folder.set(folder)
 
-        # Use imap-tools delete method to mark email as deleted
         self._mailbox.delete(str(uid))
+        self._mailbox.expunge()
 
         return True
 

--- a/tests/email/connectors/test_imap.py
+++ b/tests/email/connectors/test_imap.py
@@ -457,6 +457,7 @@ class TestIMAPConnector:
         assert result is True
         mock_mailbox.folder.set.assert_called_with("INBOX")
         mock_mailbox.delete.assert_called_once_with("123")
+        mock_mailbox.expunge.assert_called_once()
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_delete_email_different_folder(
@@ -472,6 +473,7 @@ class TestIMAPConnector:
         assert result is True
         mock_mailbox.folder.set.assert_called_with("Sent")
         mock_mailbox.delete.assert_called_once_with("456")
+        mock_mailbox.expunge.assert_called_once()
 
     def test_delete_email_not_connected(self, config: IMAPConfig) -> None:
         connector = IMAPConnector(config)


### PR DESCRIPTION
## Summary
- `delete_email()` marked emails with the IMAP `\Deleted` flag but never called `expunge()`, leaving emails recoverable on the server
- Added `self._mailbox.expunge()` call immediately after `self._mailbox.delete()` to permanently remove emails
- Updated existing delete tests to verify `expunge()` is called

Closes #110