### PR TITLE
feat: Add recipient allowlist for send permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ accounts:
 max_attachment_size: 26214400
 ```
 
+#### Recipient Allowlist
+
+Restrict which addresses the agent can send to using regex patterns under `permissions.allowed_recipients`. When set, every recipient (`to` and `cc`) must match at least one pattern or the send is denied.
+
+```yaml
+    permissions:
+      send: true
+      allowed_recipients:
+        - pattern: "^team-inbox@company\\.com$"        # Exact address
+        - pattern: "@company\\.com$"                    # Entire domain
+        - pattern: "@(sales|support)\\.company\\.com$"  # Multiple subdomains
+```
+
+- Matching is **case-insensitive**.
+- Patterns use the same ReDoS-safe regex validation as sender/subject rules.
+- Always **anchor your patterns** (e.g., `@example\.com$` not `example\.com`) to avoid overly permissive matching.
+- When `allowed_recipients` is omitted or `null`, the agent can send to any address (if `send: true`).
+- An empty list (`allowed_recipients: []`) denies all recipients.
+
 The `send_email` tool supports:
 - Multiple recipients (`to`)
 - CC recipients (`cc`)

--- a/src/read_no_evil_mcp/accounts/_validators.py
+++ b/src/read_no_evil_mcp/accounts/_validators.py
@@ -1,0 +1,76 @@
+"""Shared regex validation utilities for account configuration models."""
+
+import re
+from typing import Any
+
+# sre_parse was deprecated in 3.11 in favor of re._parser; use whichever is available
+_sre_parser: Any = getattr(re, "_parser", None)
+if _sre_parser is None:
+    import sre_parse as _sre_parser
+
+
+def _has_nested_quantifiers(pattern: str) -> bool:
+    """Check if a regex pattern contains nested quantifiers (ReDoS risk).
+
+    Walks the parsed regex AST looking for a quantifier (MAX_REPEAT/MIN_REPEAT)
+    whose body contains another quantifier.
+    """
+    try:
+        parsed = _sre_parser.parse(pattern)
+    except re.error:
+        return False
+
+    repeat_opcodes = {_sre_parser.MAX_REPEAT, _sre_parser.MIN_REPEAT}
+
+    def _contains_quantifier(items: Any) -> bool:
+        for op, av in items:
+            if op in repeat_opcodes:
+                return True
+            if op == _sre_parser.SUBPATTERN and av[3] is not None:
+                if _contains_quantifier(av[3]):
+                    return True
+            if op == _sre_parser.BRANCH:
+                for branch in av[1]:
+                    if _contains_quantifier(branch):
+                        return True
+        return False
+
+    def _walk(items: Any) -> bool:
+        for op, av in items:
+            if op in repeat_opcodes:
+                body = av[2]
+                if _contains_quantifier(body):
+                    return True
+            if op == _sre_parser.SUBPATTERN and av[3] is not None:
+                if _walk(av[3]):
+                    return True
+            if op == _sre_parser.BRANCH:
+                for branch in av[1]:
+                    if _walk(branch):
+                        return True
+        return False
+
+    return _walk(parsed)
+
+
+def validate_regex_pattern(v: str) -> str:
+    """Validate that a string is a valid regex without ReDoS risk.
+
+    Raises:
+        ValueError: If the pattern is invalid or contains nested quantifiers.
+    """
+    try:
+        re.compile(v)
+    except re.error as e:
+        raise ValueError(f"Invalid regex pattern: {e}") from e
+    try:
+        nested = _has_nested_quantifiers(v)
+    except RecursionError:
+        raise ValueError("Regex pattern is too deeply nested.") from None
+    if nested:
+        raise ValueError(
+            "Regex pattern contains nested quantifiers, which risk catastrophic "
+            "backtracking (ReDoS). Simplify the pattern to avoid nesting "
+            "repetition operators."
+        )
+    return v

--- a/src/read_no_evil_mcp/accounts/config.py
+++ b/src/read_no_evil_mcp/accounts/config.py
@@ -1,61 +1,12 @@
 """Account configuration models with discriminated union for multi-connector support."""
 
-import re
 from enum import Enum
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+from read_no_evil_mcp.accounts._validators import validate_regex_pattern
 from read_no_evil_mcp.accounts.permissions import AccountPermissions
-
-# sre_parse was deprecated in 3.11 in favor of re._parser; use whichever is available
-_sre_parser: Any = getattr(re, "_parser", None)
-if _sre_parser is None:
-    import sre_parse as _sre_parser
-
-
-def _has_nested_quantifiers(pattern: str) -> bool:
-    """Check if a regex pattern contains nested quantifiers (ReDoS risk).
-
-    Walks the parsed regex AST looking for a quantifier (MAX_REPEAT/MIN_REPEAT)
-    whose body contains another quantifier.
-    """
-    try:
-        parsed = _sre_parser.parse(pattern)
-    except re.error:
-        return False
-
-    repeat_opcodes = {_sre_parser.MAX_REPEAT, _sre_parser.MIN_REPEAT}
-
-    def _contains_quantifier(items: Any) -> bool:
-        for op, av in items:
-            if op in repeat_opcodes:
-                return True
-            if op == _sre_parser.SUBPATTERN and av[3] is not None:
-                if _contains_quantifier(av[3]):
-                    return True
-            if op == _sre_parser.BRANCH:
-                for branch in av[1]:
-                    if _contains_quantifier(branch):
-                        return True
-        return False
-
-    def _walk(items: Any) -> bool:
-        for op, av in items:
-            if op in repeat_opcodes:
-                body = av[2]
-                if _contains_quantifier(body):
-                    return True
-            if op == _sre_parser.SUBPATTERN and av[3] is not None:
-                if _walk(av[3]):
-                    return True
-            if op == _sre_parser.BRANCH:
-                for branch in av[1]:
-                    if _walk(branch):
-                        return True
-        return False
-
-    return _walk(parsed)
 
 
 class AccessLevel(str, Enum):
@@ -95,21 +46,7 @@ class SenderRule(BaseModel):
     @classmethod
     def validate_pattern(cls, v: str) -> str:
         """Validate that the pattern is a valid regex without ReDoS risk."""
-        try:
-            re.compile(v)
-        except re.error as e:
-            raise ValueError(f"Invalid regex pattern: {e}") from e
-        try:
-            nested = _has_nested_quantifiers(v)
-        except RecursionError:
-            raise ValueError("Regex pattern is too deeply nested.") from None
-        if nested:
-            raise ValueError(
-                "Regex pattern contains nested quantifiers, which risk catastrophic "
-                "backtracking (ReDoS). Simplify the pattern to avoid nesting "
-                "repetition operators."
-            )
-        return v
+        return validate_regex_pattern(v)
 
 
 class SubjectRule(BaseModel):
@@ -127,21 +64,7 @@ class SubjectRule(BaseModel):
     @classmethod
     def validate_pattern(cls, v: str) -> str:
         """Validate that the pattern is a valid regex without ReDoS risk."""
-        try:
-            re.compile(v)
-        except re.error as e:
-            raise ValueError(f"Invalid regex pattern: {e}") from e
-        try:
-            nested = _has_nested_quantifiers(v)
-        except RecursionError:
-            raise ValueError("Regex pattern is too deeply nested.") from None
-        if nested:
-            raise ValueError(
-                "Regex pattern contains nested quantifiers, which risk catastrophic "
-                "backtracking (ReDoS). Simplify the pattern to avoid nesting "
-                "repetition operators."
-            )
-        return v
+        return validate_regex_pattern(v)
 
 
 class BaseAccountConfig(BaseModel):

--- a/src/read_no_evil_mcp/accounts/permissions.py
+++ b/src/read_no_evil_mcp/accounts/permissions.py
@@ -1,6 +1,26 @@
 """Account permissions model for rights management."""
 
-from pydantic import BaseModel
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, field_validator
+
+from read_no_evil_mcp.accounts._validators import validate_regex_pattern
+
+
+class RecipientRule(BaseModel):
+    """Rule for matching allowed email recipients.
+
+    Attributes:
+        pattern: Regex pattern to match against recipient email address.
+    """
+
+    pattern: str = Field(..., min_length=1, description="Regex pattern for recipient email")
+
+    @field_validator("pattern")
+    @classmethod
+    def validate_pattern(cls, v: str) -> str:
+        """Validate that the pattern is a valid regex without ReDoS risk."""
+        return validate_regex_pattern(v)
 
 
 class AccountPermissions(BaseModel):
@@ -12,6 +32,9 @@ class AccountPermissions(BaseModel):
         send: Whether sending emails is allowed (default: False).
         move: Whether moving emails between folders is allowed (default: False).
         folders: List of allowed folders, or None for all folders (default: None).
+        allowed_recipients: Regex rules restricting who the agent can send to.
+            When None or omitted, any recipient is allowed (if send is True).
+            When set, every recipient must match at least one pattern.
     """
 
     read: bool = True
@@ -19,3 +42,4 @@ class AccountPermissions(BaseModel):
     send: bool = False
     move: bool = False
     folders: list[str] | None = None
+    allowed_recipients: list[RecipientRule] | None = None

--- a/tests/accounts/test_config.py
+++ b/tests/accounts/test_config.py
@@ -3,12 +3,12 @@
 import pytest
 from pydantic import ValidationError
 
+from read_no_evil_mcp.accounts._validators import _has_nested_quantifiers
 from read_no_evil_mcp.accounts.config import (
     AccessLevel,
     AccountConfig,
     SenderRule,
     SubjectRule,
-    _has_nested_quantifiers,
 )
 
 

--- a/tests/accounts/test_permissions.py
+++ b/tests/accounts/test_permissions.py
@@ -1,6 +1,9 @@
 """Tests for AccountPermissions."""
 
-from read_no_evil_mcp.accounts.permissions import AccountPermissions
+import pytest
+from pydantic import ValidationError
+
+from read_no_evil_mcp.accounts.permissions import AccountPermissions, RecipientRule
 
 
 class TestAccountPermissions:
@@ -13,6 +16,7 @@ class TestAccountPermissions:
         assert permissions.send is False
         assert permissions.move is False
         assert permissions.folders is None
+        assert permissions.allowed_recipients is None
 
     def test_explicit_permissions(self) -> None:
         """Test explicit permission settings."""
@@ -45,3 +49,50 @@ class TestAccountPermissions:
         permissions = AccountPermissions(read=False)
 
         assert permissions.read is False
+
+    def test_allowed_recipients_with_rules(self) -> None:
+        """Test allowed_recipients with configured rules."""
+        permissions = AccountPermissions(
+            send=True,
+            allowed_recipients=[
+                RecipientRule(pattern=r"^team@example\.com$"),
+                RecipientRule(pattern=r"@corp\.com$"),
+            ],
+        )
+
+        assert permissions.allowed_recipients is not None
+        assert len(permissions.allowed_recipients) == 2
+        assert permissions.allowed_recipients[0].pattern == r"^team@example\.com$"
+        assert permissions.allowed_recipients[1].pattern == r"@corp\.com$"
+
+    def test_allowed_recipients_none_by_default(self) -> None:
+        """Test that allowed_recipients defaults to None (no restriction)."""
+        permissions = AccountPermissions(send=True)
+
+        assert permissions.allowed_recipients is None
+
+
+class TestRecipientRule:
+    def test_valid_exact_address_pattern(self) -> None:
+        rule = RecipientRule(pattern=r"^user@example\.com$")
+        assert rule.pattern == r"^user@example\.com$"
+
+    def test_valid_domain_pattern(self) -> None:
+        rule = RecipientRule(pattern=r"@example\.com$")
+        assert rule.pattern == r"@example\.com$"
+
+    def test_valid_wildcard_pattern(self) -> None:
+        rule = RecipientRule(pattern=r".*")
+        assert rule.pattern == ".*"
+
+    def test_rejects_nested_quantifier_pattern(self) -> None:
+        with pytest.raises(ValidationError, match="nested quantifiers"):
+            RecipientRule(pattern=r"(a+)+$")
+
+    def test_rejects_invalid_regex(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid regex pattern"):
+            RecipientRule(pattern=r"[invalid")
+
+    def test_rejects_empty_pattern(self) -> None:
+        with pytest.raises(ValidationError):
+            RecipientRule(pattern="")


### PR DESCRIPTION
## Summary

- Add regex-based `allowed_recipients` field to `AccountPermissions` that restricts which addresses the AI agent can send to
- Extract shared ReDoS validator to `accounts/_validators.py` to avoid circular imports
- Validate all recipients (`to` + `cc`) against allowlist patterns with case-insensitive matching
- Raise `PermissionDeniedError` when a recipient does not match any allowed pattern
- Document the new configuration in README

## Details

When `allowed_recipients` is set under `permissions`, every recipient must match at least one regex pattern. When omitted or null, behavior is unchanged (send to anyone if `send: true`).

## Test plan

- [x] RecipientRule model validation (valid patterns, ReDoS rejection, invalid regex, empty pattern)
- [x] AccountPermissions with allowed_recipients (None default, explicit list)
- [x] SecureMailbox.send_email() with allowed/denied recipients
- [x] CC recipients validated against allowlist
- [x] Case-insensitive matching
- [x] Multiple patterns (any match permits)
- [x] Empty allowed_recipients list denies all
- [x] Denied recipient logged at info level
- [x] All 522 unit tests passing
- [x] Lint, format, and type checks passing

Closes #99