### PR TITLE
feat: Show count of blocked/filtered emails in list_emails output

### DIFF
--- a/src/read_no_evil_mcp/models.py
+++ b/src/read_no_evil_mcp/models.py
@@ -44,6 +44,8 @@ class FetchResult:
 
     items: list["SecureEmailSummary"]
     total: int
+    blocked_count: int = 0
+    hidden_count: int = 0
 
 
 @dataclass

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -74,6 +74,17 @@ def list_emails(
             if secure_email.prompt:
                 lines.append(f"    -> {secure_email.prompt}")
 
+        # Show filtering summary if any emails were filtered
+        filter_parts: list[str] = []
+        if result.blocked_count > 0:
+            noun = "email" if result.blocked_count == 1 else "emails"
+            filter_parts.append(f"{result.blocked_count} {noun} blocked by security filter")
+        if result.hidden_count > 0:
+            noun = "email" if result.hidden_count == 1 else "emails"
+            filter_parts.append(f"{result.hidden_count} {noun} hidden by sender rules")
+        if filter_parts:
+            lines.append(f"\nNote: {', '.join(filter_parts)}")
+
         shown = len(result.items)
         if shown < result.total:
             next_offset = offset + shown


### PR DESCRIPTION
## Summary
- Added `blocked_count` and `hidden_count` fields to `FetchResult` to track filtered emails
- Updated `SecureMailbox.fetch_emails()` to count blocked (prompt injection) and hidden (access rules) emails
- Updated `list_emails` tool to display filtering info (e.g., "Note: 3 emails blocked by security filter, 1 email hidden by sender rules")
- Only counts are exposed — no content from blocked/hidden emails leaks

## Test plan
- [x] Unit tests for `blocked_count` / `hidden_count` tracking in `SecureMailbox.fetch_emails()`
- [x] Unit tests for filter note display in `list_emails` tool (singular/plural, both counts, zero counts, with pagination)
- [x] All 623 tests pass
- [x] Linting, formatting, and type checking pass

Closes #177