### PR TITLE
feat: Add model-based field scanning via get_scannable_content()

### DIFF
--- a/src/read_no_evil_mcp/mailbox.py
+++ b/src/read_no_evil_mcp/mailbox.py
@@ -194,13 +194,7 @@ class SecureMailbox:
 
     def _scan_summary(self, summary: EmailSummary) -> ScanResult:
         """Scan email summary fields for prompt injection."""
-        parts: list[str] = [summary.subject]
-
-        if summary.sender.name:
-            parts.append(summary.sender.name)
-        parts.append(summary.sender.address)
-
-        combined = "\n".join(parts)
+        combined = "\n".join(summary.get_scannable_content().values())
         return self._protection.scan(combined)
 
     def fetch_emails(
@@ -336,19 +330,7 @@ class SecureMailbox:
             )
             return None
 
-        # Build content to scan: subject, sender, body
-        parts: list[str] = [email.subject]
-
-        if email.sender.name:
-            parts.append(email.sender.name)
-        parts.append(email.sender.address)
-
-        if email.body_plain:
-            parts.append(email.body_plain)
-        if email.body_html:
-            parts.append(email.body_html)
-
-        combined = "\n".join(parts)
+        combined = "\n".join(email.get_scannable_content().values())
         scan_result = self._protection.scan(combined)
 
         if scan_result.is_blocked:

--- a/tests/email/test_models.py
+++ b/tests/email/test_models.py
@@ -1,8 +1,156 @@
 """Tests for email data models."""
 
+from datetime import datetime
+
 import pytest
 
-from read_no_evil_mcp.email.models import OutgoingAttachment
+from read_no_evil_mcp.email.models import (
+    Attachment,
+    Email,
+    EmailAddress,
+    EmailSummary,
+    OutgoingAttachment,
+)
+
+
+class TestEmailSummaryGetScannableContent:
+    def test_returns_subject_and_sender_address(self) -> None:
+        summary = EmailSummary(
+            uid=1,
+            folder="INBOX",
+            subject="Hello world",
+            sender=EmailAddress(address="alice@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+        )
+
+        result = summary.get_scannable_content()
+
+        assert result == {
+            "subject": "Hello world",
+            "sender_address": "alice@example.com",
+        }
+
+    def test_includes_sender_name_when_present(self) -> None:
+        summary = EmailSummary(
+            uid=1,
+            folder="INBOX",
+            subject="Hello",
+            sender=EmailAddress(name="Alice Smith", address="alice@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+        )
+
+        result = summary.get_scannable_content()
+
+        assert result == {
+            "subject": "Hello",
+            "sender_name": "Alice Smith",
+            "sender_address": "alice@example.com",
+        }
+
+    def test_excludes_sender_name_when_none(self) -> None:
+        summary = EmailSummary(
+            uid=1,
+            folder="INBOX",
+            subject="Test",
+            sender=EmailAddress(name=None, address="bob@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+        )
+
+        result = summary.get_scannable_content()
+
+        assert "sender_name" not in result
+
+
+class TestEmailGetScannableContent:
+    def test_includes_summary_fields_and_body_plain(self) -> None:
+        email = Email(
+            uid=1,
+            folder="INBOX",
+            subject="Meeting",
+            sender=EmailAddress(name="Boss", address="boss@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_plain="See you at 3pm.",
+        )
+
+        result = email.get_scannable_content()
+
+        assert result == {
+            "subject": "Meeting",
+            "sender_name": "Boss",
+            "sender_address": "boss@example.com",
+            "body_plain": "See you at 3pm.",
+        }
+
+    def test_includes_body_html_when_present(self) -> None:
+        email = Email(
+            uid=1,
+            folder="INBOX",
+            subject="Newsletter",
+            sender=EmailAddress(address="news@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_html="<p>Hello</p>",
+        )
+
+        result = email.get_scannable_content()
+
+        assert result == {
+            "subject": "Newsletter",
+            "sender_address": "news@example.com",
+            "body_html": "<p>Hello</p>",
+        }
+
+    def test_includes_attachment_filenames(self) -> None:
+        email = Email(
+            uid=1,
+            folder="INBOX",
+            subject="Files",
+            sender=EmailAddress(address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            attachments=[
+                Attachment(filename="report.pdf", content_type="application/pdf"),
+                Attachment(filename="data.csv", content_type="text/csv"),
+            ],
+        )
+
+        result = email.get_scannable_content()
+
+        assert result == {
+            "subject": "Files",
+            "sender_address": "sender@example.com",
+            "attachment_filename_0": "report.pdf",
+            "attachment_filename_1": "data.csv",
+        }
+
+    def test_no_body_keys_when_body_is_none(self) -> None:
+        email = Email(
+            uid=1,
+            folder="INBOX",
+            subject="Empty",
+            sender=EmailAddress(address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_plain=None,
+            body_html=None,
+        )
+
+        result = email.get_scannable_content()
+
+        assert "body_plain" not in result
+        assert "body_html" not in result
+
+    def test_no_attachment_keys_when_no_attachments(self) -> None:
+        email = Email(
+            uid=1,
+            folder="INBOX",
+            subject="Plain",
+            sender=EmailAddress(address="sender@example.com"),
+            date=datetime(2026, 2, 3, 12, 0, 0),
+            body_plain="Just text.",
+            attachments=[],
+        )
+
+        result = email.get_scannable_content()
+
+        assert not any(k.startswith("attachment_filename_") for k in result)
 
 
 class TestOutgoingAttachmentCheckSize:


### PR DESCRIPTION
## Summary

- Adds `get_scannable_content() -> dict[str, str]` to `EmailSummary` and `Email` models, encapsulating knowledge of PI-susceptible fields in the models themselves
- Refactors `SecureMailbox._scan_summary()` and `get_email()` to use the new model methods instead of hardcoded field assembly
- Closes a security gap: **attachment filenames are now scanned** for prompt injection (previously missed)

## Test plan

- [x] Unit tests for `EmailSummary.get_scannable_content()` (subject, sender_name, sender_address)
- [x] Unit tests for `Email.get_scannable_content()` (body_plain, body_html, attachment filenames)
- [x] Edge case tests (no sender name, no body, no attachments, multiple attachments)
- [x] Integration test verifying attachment filenames appear in scan content
- [x] All 632 existing tests pass
- [x] ruff check, ruff format, mypy all pass

Closes #22