### PR TITLE
docs: Add keyring credential backend to v0.4 roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ The test suite includes **80+ attack payloads** across 7 categories.
 - [ ] Docker image
 
 ### v0.4 (Later)
+- [ ] Keyring credential backend ([#45](https://github.com/thekie/read-no-evil-mcp/issues/45))
 - [ ] Gmail API connector
 - [ ] Microsoft Graph connector
 - [ ] Improved obfuscation detection


### PR DESCRIPTION
## Summary
- Adds keyring credential backend to the v0.4 roadmap in README.md

## Related
- #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)