### PR TITLE
docs: Update roadmap — move attachment scanning to v0.4, link sensitivity issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,12 +424,12 @@ The test suite includes **80+ attack payloads** across 7 categories.
 - [x] Attachment support for send_email ([#72](https://github.com/thekie/read-no-evil-mcp/issues/72))
 - [x] Pagination for list_emails ([#111](https://github.com/thekie/read-no-evil-mcp/issues/111))
 - [x] Streamable HTTP transport ([#187](https://github.com/thekie/read-no-evil-mcp/issues/187))
-- [ ] Configurable sensitivity levels
-- [ ] Attachment scanning
+- [ ] Configurable sensitivity levels ([#195](https://github.com/thekie/read-no-evil-mcp/issues/195))
 - [x] Docker image ([#188](https://github.com/thekie/read-no-evil-mcp/issues/188))
 
 ### v0.4 (Later)
 - [ ] Keyring credential backend ([#45](https://github.com/thekie/read-no-evil-mcp/issues/45))
+- [ ] Attachment scanning
 - [ ] Gmail API connector
 - [ ] Microsoft Graph connector
 - [ ] Improved obfuscation detection


### PR DESCRIPTION
## Summary

- Moved **attachment scanning** from v0.3 to v0.4 roadmap (broader scope, benefits from being its own milestone)
- Linked **configurable sensitivity levels** to #195
- Created issue #195 with detailed spec for sensitivity configuration

## Changes

- `README.md`: Updated roadmap sections for v0.3 and v0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)