### PR TITLE
fix: Add explicit permissions to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, development]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION
## Summary

- Added top-level `permissions: contents: read` to `.github/workflows/ci.yml`, covering the `test` and `build` jobs
- Added top-level `permissions: contents: read` to `.github/workflows/release.yml`, covering the `build` job (publish jobs already had job-level permissions)

This resolves 3 CodeQL alerts (#1, #2, #3) for missing workflow permissions by following the principle of least privilege.

Closes #199