### PR TITLE
chore: Add GitHub issue templates (bug, feature, detection payload)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: Report a bug in read-no-evil-mcp
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Configure account with ...
+        2. Call tool `read_emails` with ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: read-no-evil-mcp version
+      placeholder: "0.5.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "macOS 15.2, Ubuntu 24.04, etc."
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Configuration
+      description: Relevant config snippet. Remove all passwords and credentials before pasting.
+      render: yaml
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/detection_payload.yml
+++ b/.github/ISSUE_TEMPLATE/detection_payload.yml
@@ -1,0 +1,47 @@
+name: Detection Payload
+description: Submit a prompt injection payload that should be detected (or is being missed)
+labels: ["detection"]
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: Attack technique category
+      options:
+        - Direct instruction override
+        - Context manipulation
+        - Role-play / persona hijack
+        - Encoding / obfuscation
+        - Multi-turn / chain-of-thought exploitation
+        - Data exfiltration
+        - Tool misuse / function-calling abuse
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: payload
+    attributes:
+      label: Payload content
+      description: The exact prompt injection text. Use a code block if it contains special formatting.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: expected-result
+    attributes:
+      label: Expected detection result
+      description: Should this payload be caught or is it currently being missed?
+      options:
+        - Should be detected (currently missed)
+        - Detected but should not be (false positive)
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Why this payload should (or should not) be detected, and any additional context.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why they were ruled out.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add `bug_report.yml` template with fields for description, repro steps, expected/actual behavior, version info, and sanitized config
- Add `feature_request.yml` template with fields for problem, proposed solution, and alternatives
- Add `detection_payload.yml` template with fields for attack category, payload content, expected detection result, and notes
- All templates use GitHub YAML form format for structured input

Closes #211