### PR TITLE
chore: Expand PyPI keywords, classifiers, and project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ requires-python = ">=3.10"
 authors = [
     { name = "read-no-evil-mcp contributors" }
 ]
-keywords = ["mcp", "email", "security", "prompt-injection", "llm"]
+keywords = [
+    "mcp", "prompt-injection", "email-security", "llm-security",
+    "ai-agents", "claude", "imap", "ai-safety", "deberta",
+    "email-gateway", "anthropic",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -23,6 +27,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Security",
     "Topic :: Communications :: Email",
+    "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 dependencies = [
     "fastmcp>=2.14.5",
@@ -50,6 +56,8 @@ read-no-evil-mcp = "read_no_evil_mcp.server:main"
 Homepage = "https://github.com/thekie/read-no-evil-mcp"
 Repository = "https://github.com/thekie/read-no-evil-mcp"
 Issues = "https://github.com/thekie/read-no-evil-mcp/issues"
+Documentation = "https://github.com/thekie/read-no-evil-mcp#readme"
+Changelog = "https://github.com/thekie/read-no-evil-mcp/blob/main/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/read_no_evil_mcp"]


### PR DESCRIPTION
## Summary
- Expanded PyPI keywords from 5 to 11 terms for better discoverability (mcp, prompt-injection, email-security, llm-security, ai-agents, claude, imap, ai-safety, deberta, email-gateway, anthropic)
- Added `Operating System :: OS Independent` and `Typing :: Typed` classifiers
- Added `Documentation` and `Changelog` project URLs

Closes #213