### PR TITLE
chore: Add upper version bounds for torch and transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.14.5",
-    "transformers>=4.30",
-    "torch",
+    "transformers>=4.30,<5.0",
+    "torch>=2.0,<3.0",
     "imap-tools",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",


### PR DESCRIPTION
## Summary
- Add upper major version bounds for `torch` and `transformers` in `pyproject.toml`
- `transformers>=4.30` → `transformers>=4.30,<5.0`
- `torch` → `torch>=2.0,<3.0`
- Allows minor/patch updates (including via Dependabot) while preventing silent breakage from major releases

## Test plan
- [x] All 650 existing tests pass
- [x] Dependency resolution verified with uv
- [x] No code changes beyond pyproject.toml

Closes #219