### PR TITLE
fix: Use non-editable install in Docker to prevent ModuleNotFoundError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-02-16
+
+### Fixed
+
+- Docker container crash on startup: use `--no-editable` install so the package is available in the runtime stage ([#251])
+
 ## [0.3.1] - 2026-02-15
 
 ### Fixed
@@ -92,11 +98,13 @@ Initial public release with core email gateway functionality:
 - Subject and sender filtering rules
 - MCP server with stdio transport
 
+[0.3.2]: https://github.com/thekie/read-no-evil-mcp/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/thekie/read-no-evil-mcp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/thekie/read-no-evil-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
 
 [#245]: https://github.com/thekie/read-no-evil-mcp/issues/245
+[#251]: https://github.com/thekie/read-no-evil-mcp/issues/251
 
 [#82]: https://github.com/thekie/read-no-evil-mcp/pull/82
 [#84]: https://github.com/thekie/read-no-evil-mcp/pull/86

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY src/ src/
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.12-slim
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "read-no-evil-mcp"
-version = "0.3.1"
+version = "0.3.2"
 description = "A secure email gateway MCP server that protects AI agents from prompt injection attacks in emails"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/read_no_evil_mcp/__init__.py
+++ b/src/read_no_evil_mcp/__init__.py
@@ -18,7 +18,7 @@ from read_no_evil_mcp.models import (
 from read_no_evil_mcp.protection.heuristic import HeuristicScanner
 from read_no_evil_mcp.protection.service import ProtectionService
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "Attachment",

--- a/uv.lock
+++ b/uv.lock
@@ -1997,7 +1997,7 @@ wheels = [
 
 [[package]]
 name = "read-no-evil-mcp"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
- Adds `--no-editable` to `uv sync` in the Dockerfile so the package is installed as a wheel, not an editable `.pth` reference
- The v0.3.1 Docker image is completely broken — the server crashes on startup with `ModuleNotFoundError`
- Bumps version to 0.3.2 with changelog entry

Closes #251

## Test plan
- [x] Local Docker build + run verified: server starts successfully
- [ ] Merge and tag `v0.3.2` — Docker publish workflow should succeed
- [ ] Cherry-pick into `development`

🤖 Generated with [Claude Code](https://claude.com/claude-code)