### PR TITLE
fix: Improve config parsing error messages for common mistakes

### DIFF
--- a/src/read_no_evil_mcp/config.py
+++ b/src/read_no_evil_mcp/config.py
@@ -78,8 +78,7 @@ class YamlConfigSettingsSource(PydanticBaseSettingsSource):
                     ) from e
                 except OSError as e:
                     raise ConfigError(
-                        f"Configuration error: Cannot read config file "
-                        f"{resolved}: {e}"
+                        f"Configuration error: Cannot read config file {resolved}: {e}"
                     ) from e
 
         return {}

--- a/src/read_no_evil_mcp/server.py
+++ b/src/read_no_evil_mcp/server.py
@@ -1,12 +1,22 @@
 """MCP server implementation for read-no-evil-mcp using FastMCP."""
 
 import os
+import sys
 
+from read_no_evil_mcp.config import load_settings
+from read_no_evil_mcp.exceptions import ConfigError
 from read_no_evil_mcp.tools import mcp
 
 
 def main() -> None:
     """Entry point for the MCP server."""
+    # Validate configuration at startup (fail fast with friendly messages)
+    try:
+        load_settings()
+    except ConfigError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
     transport = os.environ.get("RNOE_TRANSPORT", "stdio")
 
     if transport == "http":

--- a/src/read_no_evil_mcp/tools/_service.py
+++ b/src/read_no_evil_mcp/tools/_service.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from read_no_evil_mcp.accounts.config import AccountConfig
 from read_no_evil_mcp.accounts.credentials.env import EnvCredentialBackend
 from read_no_evil_mcp.accounts.service import AccountService
-from read_no_evil_mcp.config import Settings
+from read_no_evil_mcp.config import load_settings
 from read_no_evil_mcp.exceptions import ConfigError
 from read_no_evil_mcp.mailbox import SecureMailbox
 
@@ -20,7 +20,7 @@ def get_account_service() -> AccountService:
     Raises:
         ConfigError: If no accounts are configured.
     """
-    settings = Settings()
+    settings = load_settings()
 
     if not settings.accounts:
         raise ConfigError("No accounts configured. Configure accounts via YAML config file.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,8 +170,9 @@ class TestYamlConfigLoading:
         config_file.write_text("invalid: yaml: [unterminated\n")
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
-        with pytest.raises(ConfigError, match="Invalid YAML syntax"), patch.dict(
-            os.environ, env, clear=True
+        with (
+            pytest.raises(ConfigError, match="Invalid YAML syntax"),
+            patch.dict(os.environ, env, clear=True),
         ):
             Settings()
 
@@ -183,8 +184,9 @@ class TestYamlConfigLoading:
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
         try:
-            with pytest.raises(ConfigError, match="Permission denied"), patch.dict(
-                os.environ, env, clear=True
+            with (
+                pytest.raises(ConfigError, match="Permission denied"),
+                patch.dict(os.environ, env, clear=True),
             ):
                 Settings()
         finally:
@@ -287,15 +289,13 @@ class TestLoadSettings:
         """load_settings raises ConfigError for missing required fields."""
         config_file = tmp_path / "bad.yaml"
         config_file.write_text(
-            "accounts:\n"
-            "  - id: work\n"
-            "    type: imap\n"
-            "    username: user@example.com\n"
+            "accounts:\n  - id: work\n    type: imap\n    username: user@example.com\n"
         )
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
-        with pytest.raises(ConfigError, match="required field is missing"), patch.dict(
-            os.environ, env, clear=True
+        with (
+            pytest.raises(ConfigError, match="required field is missing"),
+            patch.dict(os.environ, env, clear=True),
         ):
             load_settings()
 
@@ -311,8 +311,9 @@ class TestLoadSettings:
         )
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
-        with pytest.raises(ConfigError, match="Must start with a letter"), patch.dict(
-            os.environ, env, clear=True
+        with (
+            pytest.raises(ConfigError, match="Must start with a letter"),
+            patch.dict(os.environ, env, clear=True),
         ):
             load_settings()
 
@@ -322,7 +323,8 @@ class TestLoadSettings:
         config_file.write_text("invalid: yaml: [unterminated\n")
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
-        with pytest.raises(ConfigError, match="Invalid YAML syntax"), patch.dict(
-            os.environ, env, clear=True
+        with (
+            pytest.raises(ConfigError, match="Invalid YAML syntax"),
+            patch.dict(os.environ, env, clear=True),
         ):
             load_settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
-from read_no_evil_mcp.config import Settings, YamlConfigSettingsSource
+from read_no_evil_mcp.config import Settings, YamlConfigSettingsSource, load_settings
 from read_no_evil_mcp.defaults import DEFAULT_MAX_ATTACHMENT_SIZE
+from read_no_evil_mcp.exceptions import ConfigError
 
 
 class TestSettings:
@@ -163,26 +164,28 @@ class TestYamlConfigLoading:
 
         assert settings.default_lookback_days == 7
 
-    def test_malformed_yaml_raises_error(self, tmp_path: Path) -> None:
-        """Malformed YAML raises an error during settings loading."""
-        import yaml
-
+    def test_malformed_yaml_raises_config_error(self, tmp_path: Path) -> None:
+        """Malformed YAML raises a friendly ConfigError during settings loading."""
         config_file = tmp_path / "bad.yaml"
         config_file.write_text("invalid: yaml: [unterminated\n")
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
-        with pytest.raises(yaml.YAMLError), patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ConfigError, match="Invalid YAML syntax"), patch.dict(
+            os.environ, env, clear=True
+        ):
             Settings()
 
     def test_file_permission_error(self, tmp_path: Path) -> None:
-        """A config file that can't be read raises an error."""
+        """A config file that can't be read raises a friendly ConfigError."""
         config_file = tmp_path / "noperm.yaml"
         config_file.write_text("default_lookback_days: 10\n")
         config_file.chmod(0o000)
 
         env = {"RNOE_CONFIG_FILE": str(config_file)}
         try:
-            with pytest.raises(PermissionError), patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ConfigError, match="Permission denied"), patch.dict(
+                os.environ, env, clear=True
+            ):
                 Settings()
         finally:
             config_file.chmod(0o644)
@@ -264,3 +267,62 @@ class TestYamlConfigLoading:
 
         assert first is second
         assert first["default_lookback_days"] == 42
+
+
+class TestLoadSettings:
+    """Tests for the load_settings() helper with friendly error messages."""
+
+    def test_load_settings_success(self, tmp_path: Path) -> None:
+        """load_settings returns valid Settings on good config."""
+        config_file = tmp_path / "good.yaml"
+        config_file.write_text("default_lookback_days: 30\n")
+
+        env = {"RNOE_CONFIG_FILE": str(config_file)}
+        with patch.dict(os.environ, env, clear=True):
+            settings = load_settings()
+
+        assert settings.default_lookback_days == 30
+
+    def test_load_settings_missing_required_field(self, tmp_path: Path) -> None:
+        """load_settings raises ConfigError for missing required fields."""
+        config_file = tmp_path / "bad.yaml"
+        config_file.write_text(
+            "accounts:\n"
+            "  - id: work\n"
+            "    type: imap\n"
+            "    username: user@example.com\n"
+        )
+
+        env = {"RNOE_CONFIG_FILE": str(config_file)}
+        with pytest.raises(ConfigError, match="required field is missing"), patch.dict(
+            os.environ, env, clear=True
+        ):
+            load_settings()
+
+    def test_load_settings_invalid_account_id(self, tmp_path: Path) -> None:
+        """load_settings raises ConfigError for invalid account ID format."""
+        config_file = tmp_path / "bad_id.yaml"
+        config_file.write_text(
+            "accounts:\n"
+            "  - id: 123-invalid\n"
+            "    type: imap\n"
+            "    host: mail.example.com\n"
+            "    username: user@example.com\n"
+        )
+
+        env = {"RNOE_CONFIG_FILE": str(config_file)}
+        with pytest.raises(ConfigError, match="Must start with a letter"), patch.dict(
+            os.environ, env, clear=True
+        ):
+            load_settings()
+
+    def test_load_settings_yaml_error_passes_through(self, tmp_path: Path) -> None:
+        """load_settings re-raises ConfigError from YAML parsing as-is."""
+        config_file = tmp_path / "bad.yaml"
+        config_file.write_text("invalid: yaml: [unterminated\n")
+
+        env = {"RNOE_CONFIG_FILE": str(config_file)}
+        with pytest.raises(ConfigError, match="Invalid YAML syntax"), patch.dict(
+            os.environ, env, clear=True
+        ):
+            load_settings()


### PR DESCRIPTION
## Summary

Improves error messages when users make mistakes in their `rnoe.yaml` config file, replacing raw Python tracebacks with human-readable messages.

## Changes

- **YAML syntax errors**: Wrapped `yaml.YAMLError` with friendly messages including file path, line number, and column
- **Permission errors**: Caught `PermissionError`/`OSError` with readable messages
- **Validation errors**: Added `load_settings()` helper that converts Pydantic `ValidationError` into human-readable `ConfigError` messages (missing required fields, invalid account ID format, etc.)
- **Fail-fast startup**: Server now validates config at startup and exits with a clear error message instead of failing later
- **Tests**: Updated existing tests and added new test cases for all error paths (23 tests, all passing)

## Example Error Messages

**Before:** `yaml.scanner.ScannerError: while parsing a block mapping...`
**After:** `Configuration error: Invalid YAML syntax in /path/to/rnoe.yaml at line 5, column 14: mapping values are not allowed here`

**Before:** `pydantic_core._pydantic_core.ValidationError: 1 validation error for IMAPAccountConfig host Field required`
**After:**
```
Configuration error: invalid settings:
  - 'accounts → 0 → host': required field is missing
```

Closes #266