### PR TITLE
feat: Add unread_only filter parameter to list_emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `unread_only` filter parameter for `list_emails` tool with server-side IMAP filtering ([#269])
+
 ## [0.3.3] - 2026-02-16
 
 ### Fixed
@@ -114,6 +118,8 @@ Initial public release with core email gateway functionality:
 [0.3.1]: https://github.com/thekie/read-no-evil-mcp/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/thekie/read-no-evil-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
+
+[#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
 
 [#245]: https://github.com/thekie/read-no-evil-mcp/issues/245
 [#251]: https://github.com/thekie/read-no-evil-mcp/issues/251

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ The `send_email` tool supports:
 |------|-------------|------------|
 | `list_accounts` | List configured email accounts | — |
 | `list_folders` | List folders/mailboxes | `read` |
-| `list_emails` | List emails in a folder (supports `limit`/`offset` pagination) | `read` |
+| `list_emails` | List emails in a folder (supports `limit`/`offset` pagination, `unread_only` filter) | `read` |
 | `get_email` | Get full email content by UID | `read` |
 | `send_email` | Send an email via SMTP | `send` |
 | `move_email` | Move email to another folder | `move` |

--- a/src/read_no_evil_mcp/email/connectors/base.py
+++ b/src/read_no_evil_mcp/email/connectors/base.py
@@ -37,6 +37,7 @@ class BaseConnector(ABC):
         lookback: timedelta,
         from_date: date | None = None,
         limit: int | None = None,
+        unread_only: bool = False,
     ) -> list[EmailSummary]:
         """Fetch email summaries from a folder within a time range.
 
@@ -45,6 +46,7 @@ class BaseConnector(ABC):
             lookback: How far back to look from from_date
             from_date: Starting point for lookback (default: today)
             limit: Maximum number of emails to return
+            unread_only: Only return unread (unseen) emails
 
         Returns:
             List of EmailSummary objects, newest first.

--- a/src/read_no_evil_mcp/email/connectors/imap.py
+++ b/src/read_no_evil_mcp/email/connectors/imap.py
@@ -109,6 +109,7 @@ class IMAPConnector(BaseConnector):
         lookback: timedelta,
         from_date: date | None = None,
         limit: int | None = None,
+        unread_only: bool = False,
     ) -> list[EmailSummary]:
         """Fetch email summaries from a folder within a time range.
 
@@ -117,6 +118,7 @@ class IMAPConnector(BaseConnector):
             lookback: Required. How far back to look (e.g., timedelta(days=7))
             from_date: Starting point for lookback (default: today)
             limit: Optional max number of emails to return
+            unread_only: Only return unread (unseen) emails
 
         Returns:
             List of EmailSummary, newest first
@@ -132,6 +134,8 @@ class IMAPConnector(BaseConnector):
 
         # Build IMAP criteria - filter happens server-side
         criteria = AND(date_gte=start_date, date_lt=end_date + timedelta(days=1))
+        if unread_only:
+            criteria = AND(criteria, seen=False)
 
         summaries = []
         for msg in self._mailbox.fetch(criteria, reverse=True, bulk=True):

--- a/src/read_no_evil_mcp/mailbox.py
+++ b/src/read_no_evil_mcp/mailbox.py
@@ -205,6 +205,7 @@ class SecureMailbox:
         from_date: date | None = None,
         limit: int | None = None,
         offset: int = 0,
+        unread_only: bool = False,
     ) -> FetchResult:
         """Fetch email summaries from a folder with protection scanning.
 
@@ -218,6 +219,7 @@ class SecureMailbox:
             from_date: Starting point for lookback (default: today)
             limit: Maximum number of emails to return
             offset: Number of emails to skip (default: 0)
+            unread_only: Only return unread (unseen) emails
 
         Returns:
             FetchResult with paginated items and total count.
@@ -232,6 +234,7 @@ class SecureMailbox:
             folder,
             lookback=lookback,
             from_date=from_date,
+            unread_only=unread_only,
         )
 
         secure_summaries: list[SecureEmailSummary] = []

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -23,6 +23,7 @@ def list_emails(
     days_back: int = 7,
     limit: int | None = None,
     offset: int = 0,
+    unread_only: bool = False,
 ) -> str:
     """List email summaries from a folder.
 
@@ -32,6 +33,7 @@ def list_emails(
         days_back: Number of days to look back (default: 7).
         limit: Maximum number of emails to return.
         offset: Number of emails to skip for pagination (default: 0).
+        unread_only: Only return unread emails (default: False).
     """
     if days_back < 1:
         return "Invalid parameter: days_back must be a positive integer"
@@ -48,6 +50,7 @@ def list_emails(
             lookback=timedelta(days=days_back),
             limit=limit,
             offset=offset,
+            unread_only=unread_only,
         )
 
         if not result.items:

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -144,6 +144,7 @@ class TestSecureMailbox:
             "INBOX",
             lookback=timedelta(days=7),
             from_date=None,
+            unread_only=False,
         )
         mock_protection.scan.assert_called_once()
 
@@ -2077,6 +2078,26 @@ class TestSecureMailboxPagination:
             "INBOX",
             lookback=timedelta(days=7),
             from_date=None,
+            unread_only=False,
+        )
+
+    def test_unread_only_passed_to_connector(
+        self,
+        mock_connector: MagicMock,
+        mock_protection: MagicMock,
+        default_permissions: AccountPermissions,
+    ) -> None:
+        """Test that unread_only is forwarded to the connector."""
+        mailbox = SecureMailbox(mock_connector, default_permissions, mock_protection)
+        mock_connector.fetch_emails.return_value = []
+
+        mailbox.fetch_emails("INBOX", lookback=timedelta(days=7), unread_only=True)
+
+        mock_connector.fetch_emails.assert_called_once_with(
+            "INBOX",
+            lookback=timedelta(days=7),
+            from_date=None,
+            unread_only=True,
         )
 
     def test_blocked_count_tracks_injection_filtered_emails(

--- a/tests/tools/test_list_emails.py
+++ b/tests/tools/test_list_emails.py
@@ -328,6 +328,32 @@ class TestListEmailsPagination:
         call_args = mock_mailbox.fetch_emails.call_args
         assert call_args.kwargs["offset"] == 10
 
+    def test_unread_only_passed_to_fetch_emails(self) -> None:
+        """Test that unread_only is passed to fetch_emails."""
+        mock_mailbox = _create_mock_mailbox(secure_emails=[])
+
+        with patch(
+            "read_no_evil_mcp.tools.list_emails.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            list_emails.fn(account="work", unread_only=True)
+
+        call_args = mock_mailbox.fetch_emails.call_args
+        assert call_args.kwargs["unread_only"] is True
+
+    def test_unread_only_defaults_to_false(self) -> None:
+        """Test that unread_only defaults to False."""
+        mock_mailbox = _create_mock_mailbox(secure_emails=[])
+
+        with patch(
+            "read_no_evil_mcp.tools.list_emails.create_securemailbox",
+            return_value=mock_mailbox,
+        ):
+            list_emails.fn(account="work")
+
+        call_args = mock_mailbox.fetch_emails.call_args
+        assert call_args.kwargs["unread_only"] is False
+
 
 class TestListEmailsValidation:
     def test_days_back_zero_rejected(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `unread_only` parameter to `list_emails` tool for filtering unread emails
- Uses server-side IMAP `UNSEEN` criterion for efficient filtering
- Parameter flows through the full stack: MCP tool → SecureMailbox → BaseConnector → IMAPConnector
- Default behavior unchanged (`unread_only=False`)

Closes #269

## Test plan

- [x] IMAP connector test: verifies `UNSEEN` criteria added when `unread_only=True`
- [x] IMAP connector test: verifies no `UNSEEN` criteria when `unread_only=False`
- [x] SecureMailbox test: verifies `unread_only` passed through to connector
- [x] list_emails tool test: verifies `unread_only` passed to `fetch_emails`
- [x] list_emails tool test: verifies default `unread_only=False`
- [x] All 655 existing tests pass
- [x] ruff check, ruff format, mypy all clean