### PR TITLE
fix: Prevent IMAP fetch from marking emails as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `unread_only` filter parameter for `list_emails` tool with server-side IMAP filtering ([#269])
 
+### Fixed
+
+- `is_seen` always returned `true` for listed emails because IMAP fetch marked messages as read server-side ([#270])
+
 ## [0.3.3] - 2026-02-16
 
 ### Fixed
@@ -120,6 +124,7 @@ Initial public release with core email gateway functionality:
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
 
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
+[#270]: https://github.com/thekie/read-no-evil-mcp/issues/270
 
 [#245]: https://github.com/thekie/read-no-evil-mcp/issues/245
 [#251]: https://github.com/thekie/read-no-evil-mcp/issues/251

--- a/src/read_no_evil_mcp/email/connectors/imap.py
+++ b/src/read_no_evil_mcp/email/connectors/imap.py
@@ -138,7 +138,7 @@ class IMAPConnector(BaseConnector):
             criteria = AND(criteria, seen=False)
 
         summaries = []
-        for msg in self._mailbox.fetch(criteria, reverse=True, bulk=True):
+        for msg in self._mailbox.fetch(criteria, mark_seen=False, reverse=True, bulk=True):
             if not msg.uid:
                 logger.warning("Skipping email with missing UID (subject=%r)", msg.subject)
                 continue
@@ -220,7 +220,7 @@ class IMAPConnector(BaseConnector):
         self._mailbox.folder.set(folder)
 
         # Check if email exists
-        emails = list(self._mailbox.fetch(AND(uid=str(uid))))
+        emails = list(self._mailbox.fetch(AND(uid=str(uid)), mark_seen=False))
         if not emails:
             return False
 

--- a/tests/email/connectors/test_imap.py
+++ b/tests/email/connectors/test_imap.py
@@ -110,6 +110,9 @@ class TestIMAPConnector:
         assert emails[0].sender.address == "sender@example.com"
         assert emails[0].is_seen is True
 
+        # Listing emails must not mark them as read on the server
+        assert mock_mailbox.fetch.call_args.kwargs["mark_seen"] is False
+
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_fetch_emails_unseen(self, mock_mailbox_class: MagicMock, config: IMAPConfig) -> None:
         """Test fetch_emails correctly identifies unseen messages."""
@@ -135,6 +138,9 @@ class TestIMAPConnector:
 
         assert len(emails) == 1
         assert emails[0].is_seen is False
+
+        # Listing emails must not mark them as read on the server
+        assert mock_mailbox.fetch.call_args.kwargs["mark_seen"] is False
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_fetch_emails_with_limit(
@@ -260,6 +266,9 @@ class TestIMAPConnector:
         assert email.body_html == "<p>HTML body</p>"
         assert len(email.to) == 1
         assert email.is_seen is True
+
+        # Reading an email should mark it as seen on the server (imap-tools default)
+        assert mock_mailbox.fetch.call_args.kwargs.get("mark_seen", True) is True
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_get_email_unseen(self, mock_mailbox_class: MagicMock, config: IMAPConfig) -> None:
@@ -437,6 +446,9 @@ class TestIMAPConnector:
         assert result is True
         mock_mailbox.folder.set.assert_called_with("INBOX")
         mock_mailbox.move.assert_called_once_with("123", "Archive")
+
+        # Existence check must not mark the email as read
+        assert mock_mailbox.fetch.call_args.kwargs["mark_seen"] is False
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_move_email_to_spam(self, mock_mailbox_class: MagicMock, config: IMAPConfig) -> None:


### PR DESCRIPTION
## Summary

- Pass `mark_seen=False` to `MailBox.fetch()` in `fetch_emails()` and `move_email()` so listing and moving emails no longer silently marks them as read on the IMAP server
- Keep the default `mark_seen=True` in `get_email()` so reading an email still marks it as seen (standard email client behavior)
- Add test assertions verifying `mark_seen` parameter usage across all three call sites

## Root cause

The imap-tools library defaults to `mark_seen=True` on `fetch()`, which issues an IMAP `STORE +FLAGS (\Seen)` before returning message data. This meant `is_seen` was always `true` by the time we read `msg.flags`.

## Test plan

- [x] Existing `test_fetch_emails` and `test_fetch_emails_unseen` now assert `mark_seen=False`
- [x] Existing `test_get_email` asserts `mark_seen` defaults to `True`
- [x] Existing `test_move_email_success` asserts `mark_seen=False`
- [x] Full test suite passes (655 passed)
- [x] Linting, formatting, and type checking pass

Closes #270