### PR TITLE
feat: Add skip_protection option per sender/subject rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `skip_protection` option on sender and subject rules to disable prompt injection scanning for specific senders ([#258])
+- `unscanned_list_prompt` and `unscanned_read_prompt` account settings for custom agent prompts on unscanned emails ([#258])
+- `[UNSCANNED]` marker in `list_emails` output for emails where scanning was skipped ([#258])
 - `unread_only` filter parameter for `list_emails` tool with server-side IMAP filtering ([#269])
 
 ### Fixed
@@ -123,6 +126,7 @@ Initial public release with core email gateway functionality:
 [0.3.0]: https://github.com/thekie/read-no-evil-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
 
+[#258]: https://github.com/thekie/read-no-evil-mcp/issues/258
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
 [#270]: https://github.com/thekie/read-no-evil-mcp/issues/270
 

--- a/src/read_no_evil_mcp/accounts/config.py
+++ b/src/read_no_evil_mcp/accounts/config.py
@@ -38,10 +38,15 @@ class SenderRule(BaseModel):
     Attributes:
         pattern: Regex pattern to match against sender email address.
         access: Access level to assign when pattern matches.
+        skip_protection: If True, skip prompt injection scanning for matching emails.
     """
 
     pattern: str = Field(..., min_length=1, description="Regex pattern for sender email")
     access: AccessLevel = Field(..., description="Access level when pattern matches")
+    skip_protection: bool = Field(
+        default=False,
+        description="Skip prompt injection scanning for matching emails",
+    )
 
     @field_validator("pattern")
     @classmethod
@@ -56,10 +61,15 @@ class SubjectRule(BaseModel):
     Attributes:
         pattern: Regex pattern to match against email subject.
         access: Access level to assign when pattern matches.
+        skip_protection: If True, skip prompt injection scanning for matching emails.
     """
 
     pattern: str = Field(..., min_length=1, description="Regex pattern for subject line")
     access: AccessLevel = Field(..., description="Access level when pattern matches")
+    skip_protection: bool = Field(
+        default=False,
+        description="Skip prompt injection scanning for matching emails",
+    )
 
     @field_validator("pattern")
     @classmethod
@@ -161,6 +171,14 @@ class IMAPAccountConfig(BaseAccountConfig):
     read_prompts: dict[AccessLevel, str | None] = Field(
         default_factory=dict,
         description="Agent prompts shown in get_email per access level",
+    )
+    unscanned_list_prompt: str | None = Field(
+        default=None,
+        description="Agent prompt shown in list_emails for unscanned emails (skip_protection)",
+    )
+    unscanned_read_prompt: str | None = Field(
+        default=None,
+        description="Agent prompt shown in get_email for unscanned emails (skip_protection)",
     )
 
 

--- a/src/read_no_evil_mcp/accounts/service.py
+++ b/src/read_no_evil_mcp/accounts/service.py
@@ -157,4 +157,6 @@ class AccountService:
             list_prompts=config.list_prompts or None,
             read_prompts=config.read_prompts or None,
             max_attachment_size=self._max_attachment_size,
+            unscanned_list_prompt=config.unscanned_list_prompt,
+            unscanned_read_prompt=config.unscanned_read_prompt,
         )

--- a/src/read_no_evil_mcp/models.py
+++ b/src/read_no_evil_mcp/models.py
@@ -59,6 +59,7 @@ class SecureEmailSummary:
     summary: EmailSummary
     access_level: AccessLevel
     prompt: str | None = None
+    protection_skipped: bool = False
 
 
 @dataclass
@@ -72,3 +73,4 @@ class SecureEmail:
     email: Email
     access_level: AccessLevel
     prompt: str | None = None
+    protection_skipped: bool = False

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -59,6 +59,9 @@ def get_email(account: str, folder: str, uid: int) -> str:
             if secure_email.prompt:
                 lines.append(f"-> {secure_email.prompt}")
 
+        if secure_email.protection_skipped:
+            lines.append("Protection: SKIPPED")
+
         if email.cc:
             lines.append(f"CC: {', '.join(str(addr) for addr in email.cc)}")
 

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -65,11 +65,13 @@ def list_emails(
 
             # Get access marker from the enriched model
             access_marker = ACCESS_MARKERS.get(secure_email.access_level, "")
+            unscanned_marker = " [UNSCANNED]" if secure_email.protection_skipped else ""
 
             # Build email line
             email_line = (
                 f"[{email.uid}] {date_str} | {email.sender.address} | "
                 f"{email.subject}{attachment_marker}{seen_marker}{access_marker}"
+                f"{unscanned_marker}"
             )
             lines.append(email_line)
 


### PR DESCRIPTION
## Summary

- Adds `skip_protection: true` option on sender and subject rules to disable prompt injection scanning for specific senders/subjects
- When all matching rules have `skip_protection: true`, scanning is skipped (secure-by-default: if any matching rule keeps scanning on, it stays on)
- Unscanned emails show `[UNSCANNED]` marker in `list_emails` and `Protection: SKIPPED` in `get_email`
- Adds per-account `unscanned_list_prompt` and `unscanned_read_prompt` for custom agent prompts on unscanned emails
- Default prompts warn the agent that scanning was skipped

## Test plan

- [x] 37 new unit tests covering skip_protection logic, mailbox integration, and tool output
- [x] All 692 tests pass
- [x] `ruff check`, `ruff format`, and `mypy` pass
- [x] CONFIGURATION.md updated with documentation and security warning
- [x] CHANGELOG.md updated

Closes #258