### PR TITLE
feat: Preload ML model at server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Eager ML model preloading at server startup for predictable first-request latency ([#260])
+- `RNOE_LAZY_LOAD` environment variable to opt into lazy model loading ([#260])
 - Support email addresses as account IDs with automatic env var normalization ([#259])
 - `skip_protection` option on sender and subject rules to disable prompt injection scanning for specific senders ([#258])
 - `unscanned_list_prompt` and `unscanned_read_prompt` account settings for custom agent prompts on unscanned emails ([#258])
@@ -127,6 +129,7 @@ Initial public release with core email gateway functionality:
 [0.3.0]: https://github.com/thekie/read-no-evil-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
 
+[#260]: https://github.com/thekie/read-no-evil-mcp/issues/260
 [#259]: https://github.com/thekie/read-no-evil-mcp/issues/259
 [#258]: https://github.com/thekie/read-no-evil-mcp/issues/258
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -434,6 +434,34 @@ export RNOE_ACCOUNT_WORK_PASSWORD="your-work-password"
 export RNOE_ACCOUNT_PERSONAL_PASSWORD="your-gmail-app-password"
 ```
 
+## Environment Variables
+
+### Server settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RNOE_CONFIG_FILE` | *(none)* | Path to config file (overrides default search) |
+| `RNOE_TRANSPORT` | `stdio` | Transport protocol (`stdio` or `http`) |
+| `RNOE_HTTP_HOST` | `0.0.0.0` | Bind address for HTTP transport |
+| `RNOE_HTTP_PORT` | `8000` | Port for HTTP transport |
+| `RNOE_LAZY_LOAD` | `false` | Set to `true`, `1`, or `yes` to skip model preloading at startup |
+
+### Model preloading
+
+The ML model loads during server startup, before the server accepts connections. This means the first email scan is fast, but startup takes longer (~2-3 seconds with a cached model, ~30 seconds on first run when the model downloads).
+
+If you prefer the old behavior where the model loads on first scan, set:
+
+```bash
+export RNOE_LAZY_LOAD=true
+```
+
+This is useful during development or when fast startup matters more than first-request latency.
+
+### Account passwords
+
+Passwords use the pattern `RNOE_ACCOUNT_<ID>_PASSWORD`, where `<ID>` is the account ID uppercased with non-alphanumeric characters replaced by `_`. See [Account IDs](#account-ids) for examples.
+
 ## Config File Locations
 
 read-no-evil-mcp searches for configuration in this order:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The HTTP server listens on `0.0.0.0:8000` by default. Customize with:
 | `RNOE_TRANSPORT` | `stdio` | Transport protocol (`stdio` or `http`) |
 | `RNOE_HTTP_HOST` | `0.0.0.0` | Bind address for HTTP transport |
 | `RNOE_HTTP_PORT` | `8000` | Port for HTTP transport |
+| `RNOE_LAZY_LOAD` | `false` | Skip model preloading at startup (`true`, `1`, or `yes`) |
 
 For local-only access, set `RNOE_HTTP_HOST=127.0.0.1`. The default `0.0.0.0` binds to all interfaces, which is appropriate for containerized deployments.
 
@@ -466,11 +467,13 @@ The email-specific gap (9%) is a known limitation — these attacks exploit HTML
 | Metric | Value |
 |--------|-------|
 | First startup | ~30s (one-time model download, ~500 MB) |
-| Subsequent starts | ~2–3s (model cached locally) |
+| Subsequent starts | ~2-3s (model cached locally) |
 | Per-email scan | <100 ms typical |
 | Memory footprint | ~500 MB (CPU-only PyTorch + model) |
 
-First startup downloads the [DeBERTa prompt-injection model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) from Hugging Face. After that, the model is cached in `~/.cache/huggingface/` and subsequent starts are fast. See [#91](https://github.com/thekie/read-no-evil-mcp/issues/91) for startup optimization plans.
+The ML model loads during startup, before the server accepts connections. This means the first email scan completes in under 100 ms with no cold-start delay. First startup downloads the [DeBERTa prompt-injection model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) from Hugging Face. After that, the model is cached in `~/.cache/huggingface/` and subsequent starts are fast.
+
+To defer model loading to the first scan instead, set `RNOE_LAZY_LOAD=true`.
 
 ## Roadmap
 

--- a/src/read_no_evil_mcp/protection/service.py
+++ b/src/read_no_evil_mcp/protection/service.py
@@ -55,6 +55,10 @@ class ProtectionService:
         """
         self._scanner = scanner or HeuristicScanner()
 
+    def warmup(self) -> None:
+        """Eagerly load the ML model so the first scan is fast."""
+        self._scanner.warmup()
+
     def scan(self, content: str) -> ScanResult:
         """Scan content for prompt injection attacks.
 

--- a/src/read_no_evil_mcp/tools/_app.py
+++ b/src/read_no_evil_mcp/tools/_app.py
@@ -1,6 +1,28 @@
 """Shared FastMCP application instance."""
 
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastmcp import FastMCP
 
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(server: FastMCP) -> AsyncIterator[None]:
+    """Preload the ML model before accepting connections."""
+    if os.environ.get("RNOE_LAZY_LOAD", "").lower() in ("1", "true", "yes"):
+        logger.info("Lazy loading enabled, skipping model preload")
+    else:
+        logger.info("Preloading prompt injection model")
+        from read_no_evil_mcp.protection.service import ProtectionService
+
+        ProtectionService().warmup()
+        logger.info("Model preloaded successfully")
+    yield
+
+
 # Create the shared FastMCP server instance
-mcp = FastMCP(name="read-no-evil-mcp")
+mcp = FastMCP(name="read-no-evil-mcp", lifespan=_lifespan)

--- a/tests/protection/test_service.py
+++ b/tests/protection/test_service.py
@@ -110,6 +110,12 @@ class TestProtectionService:
         )
         assert result.is_safe
 
+    def test_warmup_delegates_to_scanner(self) -> None:
+        mock_scanner = MagicMock(spec=HeuristicScanner)
+        service = ProtectionService(scanner=mock_scanner)
+        service.warmup()
+        mock_scanner.warmup.assert_called_once()
+
     def test_custom_scanner(self) -> None:
         mock_scanner = MagicMock(spec=HeuristicScanner)
         mock_scanner.scan.return_value = ScanResult(


### PR DESCRIPTION
## Summary

- Load the DeBERTa prompt injection model during FastMCP lifespan initialization, before the server accepts connections
- Store the classifier as a module-level singleton so all HeuristicScanner instances share the same loaded model
- Add RNOE_LAZY_LOAD environment variable (true, 1, or yes) to opt into lazy loading

## Details

The ML model was previously lazy-loaded on the first scan() call, causing the first email request to hang for ~2-3s (cached model) or ~30s (first download). The server reported ready but was not truly ready to serve.

Now the model loads during the FastMCP lifespan hook -- before yield, before the server accepts connections. For both HTTP and stdio transports, the server is genuinely ready when it starts listening.

## Test plan

- [x] Unit test: HeuristicScanner.warmup() loads the shared classifier
- [x] Unit test: ProtectionService.warmup() delegates to scanner
- [x] Unit test: Lifespan preloads model when RNOE_LAZY_LOAD is unset
- [x] Unit test: Lifespan skips preload for all truthy values of RNOE_LAZY_LOAD
- [x] Unit test: Non-truthy values (e.g. false) still trigger preload
- [x] All 711 tests pass
- [x] Linting, formatting, and type checks pass

Closes #260