### PR TITLE
feat: Notify agent when a newer MCP version is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `unscanned_list_prompt` and `unscanned_read_prompt` account settings for custom agent prompts on unscanned emails ([#258])
 - `[UNSCANNED]` marker in `list_emails` output for emails where scanning was skipped ([#258])
 - `unread_only` filter parameter for `list_emails` tool with server-side IMAP filtering ([#269])
+- Version update check that notifies the agent when a newer release is available ([#264])
 
 ### Fixed
 
@@ -132,6 +133,7 @@ Initial public release with core email gateway functionality:
 [#260]: https://github.com/thekie/read-no-evil-mcp/issues/260
 [#259]: https://github.com/thekie/read-no-evil-mcp/issues/259
 [#258]: https://github.com/thekie/read-no-evil-mcp/issues/258
+[#264]: https://github.com/thekie/read-no-evil-mcp/issues/264
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
 [#270]: https://github.com/thekie/read-no-evil-mcp/issues/270
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -445,6 +445,7 @@ export RNOE_ACCOUNT_PERSONAL_PASSWORD="your-gmail-app-password"
 | `RNOE_HTTP_HOST` | `0.0.0.0` | Bind address for HTTP transport |
 | `RNOE_HTTP_PORT` | `8000` | Port for HTTP transport |
 | `RNOE_LAZY_LOAD` | `false` | Set to `true`, `1`, or `yes` to skip model preloading at startup |
+| `RNOE_DISABLE_UPDATE_CHECK` | `false` | Set to `true`, `1`, or `yes` to disable the PyPI version check |
 
 ### Model preloading
 
@@ -457,6 +458,16 @@ export RNOE_LAZY_LOAD=true
 ```
 
 This is useful during development or when fast startup matters more than first-request latency.
+
+### Version update check
+
+On the first tool call of each session, the server checks PyPI for a newer version of `read-no-evil-mcp`. If one is available, a one-time notice is appended to the tool response. The check uses a 2-second timeout and fails silently — no notice appears if PyPI is unreachable.
+
+To disable the check:
+
+```bash
+export RNOE_DISABLE_UPDATE_CHECK=true
+```
 
 ### Account passwords
 

--- a/src/read_no_evil_mcp/tools/_update_notice.py
+++ b/src/read_no_evil_mcp/tools/_update_notice.py
@@ -1,0 +1,41 @@
+"""Decorator that appends a one-time version update notice to tool responses."""
+
+import logging
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from read_no_evil_mcp.version_check import get_update_notice
+
+logger = logging.getLogger(__name__)
+
+_notice_shown: bool = False
+
+
+def append_update_notice(func: Callable[..., str]) -> Callable[..., str]:
+    """Wrap an MCP tool to append an update notice on the first call."""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> str:
+        global _notice_shown  # noqa: PLW0603
+
+        result = func(*args, **kwargs)
+
+        if _notice_shown:
+            return result
+
+        _notice_shown = True
+
+        notice = get_update_notice()
+        if notice:
+            return f"{result}\n\n---\n{notice}"
+
+        return result
+
+    return wrapper
+
+
+def _reset() -> None:
+    """Reset module state. For testing only."""
+    global _notice_shown  # noqa: PLW0603
+    _notice_shown = False

--- a/src/read_no_evil_mcp/tools/delete_email.py
+++ b/src/read_no_evil_mcp/tools/delete_email.py
@@ -3,9 +3,11 @@
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def delete_email(account: str, folder: str, uid: int) -> str:
     """Delete an email by UID.

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -5,6 +5,7 @@ from read_no_evil_mcp.mailbox import PromptInjectionError
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 # Mapping of access levels to display names
 ACCESS_DISPLAY: dict[AccessLevel, str] = {
@@ -14,6 +15,7 @@ ACCESS_DISPLAY: dict[AccessLevel, str] = {
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def get_email(account: str, folder: str, uid: int) -> str:
     """Get full email content by UID.

--- a/src/read_no_evil_mcp/tools/list_accounts.py
+++ b/src/read_no_evil_mcp/tools/list_accounts.py
@@ -2,9 +2,11 @@
 
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._service import list_configured_accounts
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 
 @mcp.tool
+@append_update_notice
 def list_accounts() -> str:
     """List all configured email account IDs.
 

--- a/src/read_no_evil_mcp/tools/list_emails.py
+++ b/src/read_no_evil_mcp/tools/list_emails.py
@@ -6,6 +6,7 @@ from read_no_evil_mcp.accounts.config import AccessLevel
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 # Mapping of access levels to markers shown in list output
 ACCESS_MARKERS: dict[AccessLevel, str] = {
@@ -16,6 +17,7 @@ ACCESS_MARKERS: dict[AccessLevel, str] = {
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def list_emails(
     account: str,

--- a/src/read_no_evil_mcp/tools/list_folders.py
+++ b/src/read_no_evil_mcp/tools/list_folders.py
@@ -3,9 +3,11 @@
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def list_folders(account: str) -> str:
     """List all available email folders/mailboxes.

--- a/src/read_no_evil_mcp/tools/move_email.py
+++ b/src/read_no_evil_mcp/tools/move_email.py
@@ -3,9 +3,11 @@
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
     """Move an email to a target folder.

--- a/src/read_no_evil_mcp/tools/send_email.py
+++ b/src/read_no_evil_mcp/tools/send_email.py
@@ -8,6 +8,7 @@ from read_no_evil_mcp.email.models import OutgoingAttachment
 from read_no_evil_mcp.tools._app import mcp
 from read_no_evil_mcp.tools._error_handler import handle_tool_errors
 from read_no_evil_mcp.tools._service import create_securemailbox
+from read_no_evil_mcp.tools._update_notice import append_update_notice
 from read_no_evil_mcp.tools.models import AttachmentInput
 
 
@@ -57,6 +58,7 @@ def _parse_attachments(
 
 
 @mcp.tool
+@append_update_notice
 @handle_tool_errors
 def send_email(
     account: str,

--- a/src/read_no_evil_mcp/version_check.py
+++ b/src/read_no_evil_mcp/version_check.py
@@ -1,0 +1,88 @@
+"""Check PyPI for newer versions and generate a one-time update notice."""
+
+import json
+import logging
+import os
+import urllib.request
+from urllib.error import URLError
+
+from packaging.version import InvalidVersion, Version
+
+from read_no_evil_mcp import __version__
+
+logger = logging.getLogger(__name__)
+
+PYPI_URL = "https://pypi.org/pypi/read-no-evil-mcp/json"
+PYPI_TIMEOUT_SECONDS = 2
+
+_update_checked: bool = False
+_update_notice: str | None = None
+
+
+def is_update_available(current: str, latest: str) -> bool:
+    """Compare version strings and return True if latest is newer."""
+    try:
+        return Version(latest) > Version(current)
+    except InvalidVersion:
+        return False
+
+
+def get_latest_version() -> str | None:
+    """Query PyPI for the latest published version.
+
+    Returns the version string, or None if the check fails for any reason.
+    """
+    try:
+        req = urllib.request.Request(PYPI_URL, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=PYPI_TIMEOUT_SECONDS) as resp:
+            data = json.loads(resp.read(1_000_000))  # Cap read to 1MB
+        version = data["info"]["version"]
+        if not isinstance(version, str):
+            return None
+        # Validate it parses as a version
+        Version(version)
+        return version
+    except (URLError, OSError, KeyError, json.JSONDecodeError, InvalidVersion):
+        return None
+
+
+def get_update_notice() -> str | None:
+    """Return a formatted update notice, or None.
+
+    Checks PyPI at most once per process. Subsequent calls return the cached result.
+    Returns None if the check is disabled, fails, or the version is current.
+    """
+    global _update_checked, _update_notice  # noqa: PLW0603
+
+    if _update_checked:
+        return _update_notice
+
+    _update_checked = True
+
+    if os.environ.get("RNOE_DISABLE_UPDATE_CHECK", "").lower() in ("1", "true", "yes"):
+        logger.debug("Update check disabled via RNOE_DISABLE_UPDATE_CHECK")
+        return None
+
+    latest = get_latest_version()
+    if latest is None:
+        logger.debug("Could not determine latest version from PyPI")
+        return None
+
+    if not is_update_available(__version__, latest):
+        logger.debug("Running version %s is up to date", __version__)
+        return None
+
+    _update_notice = (
+        f"\u26a0\ufe0f UPDATE AVAILABLE: read-no-evil-mcp v{latest} is available "
+        f"(you are running v{__version__}).\n"
+        "Please ask your user to update to get the latest security protections."
+    )
+    logger.debug("Update available: %s -> %s", __version__, latest)
+    return _update_notice
+
+
+def _reset() -> None:
+    """Reset module state. For testing only."""
+    global _update_checked, _update_notice  # noqa: PLW0603
+    _update_checked = False
+    _update_notice = None

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -1,0 +1,165 @@
+"""Tests for version_check module."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from read_no_evil_mcp import version_check
+
+
+@pytest.fixture(autouse=True)
+def reset_version_check() -> None:
+    """Reset version_check module state before each test."""
+    version_check._reset()
+
+
+class TestIsUpdateAvailable:
+    def test_newer_version_available(self) -> None:
+        assert version_check.is_update_available("0.3.0", "0.4.0") is True
+
+    def test_older_version_not_available(self) -> None:
+        assert version_check.is_update_available("0.4.0", "0.3.0") is False
+
+    def test_equal_versions_not_available(self) -> None:
+        assert version_check.is_update_available("0.4.0", "0.4.0") is False
+
+    def test_pre_release_less_than_release(self) -> None:
+        """Pre-release version running, release available — update is available."""
+        assert version_check.is_update_available("0.4.0.dev0", "0.4.0") is True
+
+    def test_invalid_current_version_returns_false(self) -> None:
+        assert version_check.is_update_available("not-a-version", "0.4.0") is False
+
+    def test_invalid_latest_version_returns_false(self) -> None:
+        assert version_check.is_update_available("0.4.0", "not-a-version") is False
+
+
+class TestGetLatestVersion:
+    def _make_urlopen_mock(self, payload: object) -> MagicMock:
+        body = json.dumps(payload).encode()
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=body)))
+        cm.__exit__ = MagicMock(return_value=False)
+        return cm
+
+    def test_success_returns_version_string(self) -> None:
+        payload = {"info": {"version": "0.5.0"}}
+        with patch("urllib.request.urlopen", return_value=self._make_urlopen_mock(payload)):
+            result = version_check.get_latest_version()
+        assert result == "0.5.0"
+
+    def test_timeout_returns_none(self) -> None:
+        from urllib.error import URLError
+
+        with patch("urllib.request.urlopen", side_effect=URLError("timed out")):
+            result = version_check.get_latest_version()
+        assert result is None
+
+    def test_http_error_returns_none(self) -> None:
+        from urllib.error import URLError
+
+        with patch("urllib.request.urlopen", side_effect=URLError("HTTP error")):
+            result = version_check.get_latest_version()
+        assert result is None
+
+    def test_invalid_json_returns_none(self) -> None:
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=b"not json")))
+        cm.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=cm):
+            result = version_check.get_latest_version()
+        assert result is None
+
+    def test_missing_key_returns_none(self) -> None:
+        payload = {"info": {}}  # missing "version" key
+        with patch("urllib.request.urlopen", return_value=self._make_urlopen_mock(payload)):
+            result = version_check.get_latest_version()
+        assert result is None
+
+    def test_non_string_version_returns_none(self) -> None:
+        payload = {"info": {"version": 42}}
+        with patch("urllib.request.urlopen", return_value=self._make_urlopen_mock(payload)):
+            result = version_check.get_latest_version()
+        assert result is None
+
+    def test_invalid_version_string_returns_none(self) -> None:
+        payload = {"info": {"version": "not-a-semver!!!"}}
+        with patch("urllib.request.urlopen", return_value=self._make_urlopen_mock(payload)):
+            result = version_check.get_latest_version()
+        assert result is None
+
+
+class TestGetUpdateNotice:
+    def _make_urlopen_mock(self, version: str) -> MagicMock:
+        payload = {"info": {"version": version}}
+        body = json.dumps(payload).encode()
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=body)))
+        cm.__exit__ = MagicMock(return_value=False)
+        return cm
+
+    def test_returns_formatted_notice_when_update_available(self) -> None:
+        with (
+            patch("urllib.request.urlopen", return_value=self._make_urlopen_mock("0.9.0")),
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            result = version_check.get_update_notice()
+        assert result == (
+            "\u26a0\ufe0f UPDATE AVAILABLE: read-no-evil-mcp v0.9.0 is available "
+            "(you are running v0.3.0).\n"
+            "Please ask your user to update to get the latest security protections."
+        )
+
+    def test_returns_none_when_up_to_date(self) -> None:
+        with (
+            patch("urllib.request.urlopen", return_value=self._make_urlopen_mock("0.3.0")),
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            result = version_check.get_update_notice()
+        assert result is None
+
+    def test_returns_none_when_check_fails(self) -> None:
+        from urllib.error import URLError
+
+        with patch("urllib.request.urlopen", side_effect=URLError("network error")):
+            result = version_check.get_update_notice()
+        assert result is None
+
+    def test_caches_result_and_calls_urllib_only_once(self) -> None:
+        with (
+            patch(
+                "urllib.request.urlopen", return_value=self._make_urlopen_mock("0.9.0")
+            ) as mock_urlopen,
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            first = version_check.get_update_notice()
+            second = version_check.get_update_notice()
+
+        assert first == second
+        assert mock_urlopen.call_count == 1
+
+    def test_returns_none_when_disable_env_var_is_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RNOE_DISABLE_UPDATE_CHECK", "true")
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = version_check.get_update_notice()
+        assert result is None
+        mock_urlopen.assert_not_called()
+
+    def test_returns_none_when_disable_env_var_is_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RNOE_DISABLE_UPDATE_CHECK", "1")
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = version_check.get_update_notice()
+        assert result is None
+        mock_urlopen.assert_not_called()
+
+    def test_returns_none_when_disable_env_var_is_yes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("RNOE_DISABLE_UPDATE_CHECK", "yes")
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            result = version_check.get_update_notice()
+        assert result is None
+        mock_urlopen.assert_not_called()

--- a/tests/tools/test_update_notice.py
+++ b/tests/tools/test_update_notice.py
@@ -1,0 +1,92 @@
+"""Tests for _update_notice decorator."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from read_no_evil_mcp import version_check
+from read_no_evil_mcp.tools._update_notice import _reset as notice_reset
+from read_no_evil_mcp.tools._update_notice import append_update_notice
+
+
+@pytest.fixture(autouse=True)
+def reset_state() -> None:
+    """Reset both decorator and version_check module state before each test."""
+    notice_reset()
+    version_check._reset()
+
+
+def _make_urlopen_mock(version: str) -> MagicMock:
+    payload = {"info": {"version": version}}
+    body = json.dumps(payload).encode()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=MagicMock(read=MagicMock(return_value=body)))
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+class TestAppendUpdateNoticeDecorator:
+    def test_shows_notice_on_first_call(self) -> None:
+        """Decorator appends update notice on first invocation."""
+
+        @append_update_notice
+        def my_tool() -> str:
+            return "tool output"
+
+        with (
+            patch("urllib.request.urlopen", return_value=_make_urlopen_mock("0.9.0")),
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            result = my_tool()
+
+        assert result == (
+            "tool output\n\n---\n"
+            "\u26a0\ufe0f UPDATE AVAILABLE: read-no-evil-mcp v0.9.0 is available "
+            "(you are running v0.3.0).\n"
+            "Please ask your user to update to get the latest security protections."
+        )
+
+    def test_does_not_show_notice_on_second_call(self) -> None:
+        """Decorator does not append notice after first invocation."""
+
+        @append_update_notice
+        def my_tool() -> str:
+            return "tool output"
+
+        with (
+            patch("urllib.request.urlopen", return_value=_make_urlopen_mock("0.9.0")),
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            my_tool()
+            result = my_tool()
+
+        assert result == "tool output"
+
+    def test_passes_through_when_no_update_available(self) -> None:
+        """Decorator returns unmodified result when version is current."""
+
+        @append_update_notice
+        def my_tool() -> str:
+            return "tool output"
+
+        with (
+            patch("urllib.request.urlopen", return_value=_make_urlopen_mock("0.3.0")),
+            patch("read_no_evil_mcp.version_check.__version__", "0.3.0"),
+        ):
+            result = my_tool()
+
+        assert result == "tool output"
+
+    def test_passes_through_when_check_fails(self) -> None:
+        """Decorator returns unmodified result when PyPI check fails."""
+        from urllib.error import URLError
+
+        @append_update_notice
+        def my_tool() -> str:
+            return "tool output"
+
+        with patch("urllib.request.urlopen", side_effect=URLError("network error")):
+            result = my_tool()
+
+        assert result == "tool output"


### PR DESCRIPTION
## Summary

- Checks PyPI for a newer version on the first tool call of each session
- Appends a one-time update notice to the tool response if a newer version exists
- Fails silently on network errors or timeouts (2-second cap)
- Disable with `RNOE_DISABLE_UPDATE_CHECK=true` for air-gapped environments

## Test plan

- [x] 24 new unit tests covering version comparison, PyPI response handling, caching, env var disable, and decorator behavior
- [x] All 735 tests pass (`uv run pytest`)
- [x] Lint, format, and type checks pass (`ruff check`, `ruff format`, `mypy`)

Closes #264