### PR TITLE
Refactor AccountConfig into base class + discriminated union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `unread_only` filter parameter for `list_emails` tool with server-side IMAP filtering ([#269])
 - Version update check that notifies the agent when a newer release is available ([#264])
 
+### Changed
+
+- Extracted shared account fields into `BaseAccountConfig` to prepare for multi-connector support ([#283])
+
 ### Fixed
 
 - `is_seen` always returned `true` for listed emails because IMAP fetch marked messages as read server-side ([#270])
@@ -136,6 +140,7 @@ Initial public release with core email gateway functionality:
 [#264]: https://github.com/thekie/read-no-evil-mcp/issues/264
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
 [#270]: https://github.com/thekie/read-no-evil-mcp/issues/270
+[#283]: https://github.com/thekie/read-no-evil-mcp/issues/283
 
 [#245]: https://github.com/thekie/read-no-evil-mcp/issues/245
 [#251]: https://github.com/thekie/read-no-evil-mcp/issues/251

--- a/tests/accounts/test_config.py
+++ b/tests/accounts/test_config.py
@@ -7,6 +7,8 @@ from read_no_evil_mcp.accounts._validators import _has_nested_quantifiers
 from read_no_evil_mcp.accounts.config import (
     AccessLevel,
     AccountConfig,
+    BaseAccountConfig,
+    IMAPAccountConfig,
     SenderRule,
     SubjectRule,
 )
@@ -385,3 +387,42 @@ class TestSubjectRuleReDoS:
     def test_accepts_safe_pattern(self) -> None:
         rule = SubjectRule(pattern=r"(?i)\[URGENT\]", access=AccessLevel.ASK_BEFORE_READ)
         assert rule.pattern == r"(?i)\[URGENT\]"
+
+
+class TestBaseAccountConfig:
+    """Tests for BaseAccountConfig."""
+
+    def test_imap_config_is_instance_of_base(self) -> None:
+        """IMAPAccountConfig inherits from BaseAccountConfig."""
+        config = IMAPAccountConfig(
+            id="work",
+            host="mail.example.com",
+            username="user@example.com",
+        )
+        assert isinstance(config, BaseAccountConfig)
+
+    def test_account_config_alias_is_imap(self) -> None:
+        """AccountConfig type alias resolves to IMAPAccountConfig."""
+        assert AccountConfig is IMAPAccountConfig
+
+    def test_shared_fields_live_on_base(self) -> None:
+        """Fields shared across account types are defined on BaseAccountConfig."""
+        base_fields = BaseAccountConfig.model_fields
+        for field in (
+            "id",
+            "permissions",
+            "protection",
+            "sender_rules",
+            "subject_rules",
+            "list_prompts",
+            "read_prompts",
+            "unscanned_list_prompt",
+            "unscanned_read_prompt",
+        ):
+            assert field in base_fields, f"Expected '{field}' on BaseAccountConfig"
+
+    def test_imap_specific_fields_not_on_base(self) -> None:
+        """IMAP-specific fields are NOT defined on BaseAccountConfig."""
+        base_fields = BaseAccountConfig.model_fields
+        for field in ("host", "port", "username", "ssl", "type"):
+            assert field not in base_fields, f"'{field}' should not be on BaseAccountConfig"


### PR DESCRIPTION
## Summary

- Extracted shared account fields (permissions, protection, access rules, prompts) from `IMAPAccountConfig` into `BaseAccountConfig`
- `IMAPAccountConfig` now inherits shared fields and keeps only IMAP-specific connection settings (host, port, username, ssl, smtp_*, from_address, from_name, sent_folder)
- `AccountConfig` type alias is ready for conversion to a Pydantic discriminated union when a second connector type is added (documented with copy-paste code in comment)

## Test plan

- [x] All 735 existing tests pass without modification
- [x] 4 new tests verify the inheritance structure and field placement
- [x] mypy strict mode passes
- [x] ruff check and format pass

Closes #283