### PR TITLE
refactor: Change email UID type from int to str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Extracted shared account fields into `BaseAccountConfig` to prepare for multi-connector support ([#283])
+- Changed email UID type from `int` to `str` to support non-numeric message IDs ([#284])
 
 ### Fixed
 
@@ -141,6 +142,7 @@ Initial public release with core email gateway functionality:
 [#269]: https://github.com/thekie/read-no-evil-mcp/issues/269
 [#270]: https://github.com/thekie/read-no-evil-mcp/issues/270
 [#283]: https://github.com/thekie/read-no-evil-mcp/issues/283
+[#284]: https://github.com/thekie/read-no-evil-mcp/issues/284
 
 [#245]: https://github.com/thekie/read-no-evil-mcp/issues/245
 [#251]: https://github.com/thekie/read-no-evil-mcp/issues/251

--- a/src/read_no_evil_mcp/email/connectors/base.py
+++ b/src/read_no_evil_mcp/email/connectors/base.py
@@ -54,7 +54,7 @@ class BaseConnector(ABC):
         ...
 
     @abstractmethod
-    def get_email(self, folder: str, uid: int) -> Email | None:
+    def get_email(self, folder: str, uid: str) -> Email | None:
         """Fetch full email content by UID.
 
         Args:
@@ -67,7 +67,7 @@ class BaseConnector(ABC):
         ...
 
     @abstractmethod
-    def move_email(self, folder: str, uid: int, target_folder: str) -> bool:
+    def move_email(self, folder: str, uid: str, target_folder: str) -> bool:
         """Move an email to a target folder.
 
         Args:
@@ -81,7 +81,7 @@ class BaseConnector(ABC):
         ...
 
     @abstractmethod
-    def delete_email(self, folder: str, uid: int) -> bool:
+    def delete_email(self, folder: str, uid: str) -> bool:
         """Delete an email by UID.
 
         Args:

--- a/src/read_no_evil_mcp/email/connectors/imap.py
+++ b/src/read_no_evil_mcp/email/connectors/imap.py
@@ -147,7 +147,7 @@ class IMAPConnector(BaseConnector):
 
             summaries.append(
                 EmailSummary(
-                    uid=int(msg.uid),
+                    uid=msg.uid,
                     folder=folder,
                     subject=msg.subject or "(no subject)",
                     sender=sender,
@@ -162,14 +162,14 @@ class IMAPConnector(BaseConnector):
 
         return summaries
 
-    def get_email(self, folder: str, uid: int) -> Email | None:
+    def get_email(self, folder: str, uid: str) -> Email | None:
         """Fetch full email content by UID."""
         if not self._mailbox:
             raise RuntimeError("Not connected. Call connect() first.")
 
         self._mailbox.folder.set(folder)
 
-        for msg in self._mailbox.fetch(AND(uid=str(uid))):
+        for msg in self._mailbox.fetch(AND(uid=uid)):
             if not msg.uid:
                 logger.warning("Skipping email with missing UID (subject=%r)", msg.subject)
                 continue
@@ -186,7 +186,7 @@ class IMAPConnector(BaseConnector):
             ]
 
             return Email(
-                uid=int(msg.uid),
+                uid=msg.uid,
                 folder=folder,
                 subject=msg.subject or "(no subject)",
                 sender=sender,
@@ -203,7 +203,7 @@ class IMAPConnector(BaseConnector):
 
         return None
 
-    def move_email(self, folder: str, uid: int, target_folder: str) -> bool:
+    def move_email(self, folder: str, uid: str, target_folder: str) -> bool:
         """Move an email to a target folder.
 
         Args:
@@ -220,15 +220,15 @@ class IMAPConnector(BaseConnector):
         self._mailbox.folder.set(folder)
 
         # Check if email exists
-        emails = list(self._mailbox.fetch(AND(uid=str(uid)), mark_seen=False))
+        emails = list(self._mailbox.fetch(AND(uid=uid), mark_seen=False))
         if not emails:
             return False
 
         # Move email to target folder
-        self._mailbox.move(str(uid), target_folder)
+        self._mailbox.move(uid, target_folder)
         return True
 
-    def delete_email(self, folder: str, uid: int) -> bool:
+    def delete_email(self, folder: str, uid: str) -> bool:
         """Delete an email by UID.
 
         Args:
@@ -243,7 +243,7 @@ class IMAPConnector(BaseConnector):
 
         self._mailbox.folder.set(folder)
 
-        self._mailbox.delete(str(uid))
+        self._mailbox.delete(uid)
         self._mailbox.expunge()
 
         return True

--- a/src/read_no_evil_mcp/email/models.py
+++ b/src/read_no_evil_mcp/email/models.py
@@ -89,7 +89,7 @@ class OutgoingAttachment(BaseModel):
 class EmailSummary(BaseModel):
     """Lightweight email representation for list views."""
 
-    uid: int
+    uid: str
     folder: str
     subject: str
     sender: EmailAddress

--- a/src/read_no_evil_mcp/mailbox.py
+++ b/src/read_no_evil_mcp/mailbox.py
@@ -39,7 +39,7 @@ def _compile_recipient_pattern(pattern: str) -> re.Pattern[str]:
 class PromptInjectionError(Exception):
     """Raised when prompt injection is detected in email content."""
 
-    def __init__(self, scan_result: ScanResult, email_uid: int, folder: str) -> None:
+    def __init__(self, scan_result: ScanResult, email_uid: str, folder: str) -> None:
         self.scan_result = scan_result
         self.email_uid = email_uid
         self.folder = folder
@@ -336,7 +336,7 @@ class SecureMailbox:
             hidden_count=hidden_count,
         )
 
-    def get_email(self, folder: str, uid: int) -> SecureEmail | None:
+    def get_email(self, folder: str, uid: str) -> SecureEmail | None:
         """Get full email content by UID with protection scanning.
 
         Scans email content for prompt injection attacks before returning.
@@ -472,7 +472,7 @@ class SecureMailbox:
             attachments=attachments,
         )
 
-    def move_email(self, folder: str, uid: int, target_folder: str) -> bool:
+    def move_email(self, folder: str, uid: str, target_folder: str) -> bool:
         """Move an email to a target folder.
 
         Args:
@@ -492,7 +492,7 @@ class SecureMailbox:
 
         return self._connector.move_email(folder, uid, target_folder)
 
-    def delete_email(self, folder: str, uid: int) -> bool:
+    def delete_email(self, folder: str, uid: str) -> bool:
         """Delete an email by UID.
 
         Args:

--- a/src/read_no_evil_mcp/tools/delete_email.py
+++ b/src/read_no_evil_mcp/tools/delete_email.py
@@ -9,7 +9,7 @@ from read_no_evil_mcp.tools._update_notice import append_update_notice
 @mcp.tool
 @append_update_notice
 @handle_tool_errors
-def delete_email(account: str, folder: str, uid: int) -> str:
+def delete_email(account: str, folder: str, uid: str) -> str:
     """Delete an email by UID.
 
     Args:
@@ -17,8 +17,8 @@ def delete_email(account: str, folder: str, uid: int) -> str:
         folder: Folder containing the email.
         uid: Unique identifier of the email.
     """
-    if uid < 1:
-        return "Invalid parameter: uid must be a positive integer"
+    if not uid or not uid.strip():
+        return "Invalid parameter: uid must not be empty"
     if not folder or not folder.strip():
         return "Invalid parameter: folder must not be empty"
 

--- a/src/read_no_evil_mcp/tools/get_email.py
+++ b/src/read_no_evil_mcp/tools/get_email.py
@@ -17,7 +17,7 @@ ACCESS_DISPLAY: dict[AccessLevel, str] = {
 @mcp.tool
 @append_update_notice
 @handle_tool_errors
-def get_email(account: str, folder: str, uid: int) -> str:
+def get_email(account: str, folder: str, uid: str) -> str:
     """Get full email content by UID.
 
     Args:
@@ -25,8 +25,8 @@ def get_email(account: str, folder: str, uid: int) -> str:
         folder: Folder containing the email.
         uid: Unique identifier of the email.
     """
-    if uid < 1:
-        return "Invalid parameter: uid must be a positive integer"
+    if not uid or not uid.strip():
+        return "Invalid parameter: uid must not be empty"
     if not folder or not folder.strip():
         return "Invalid parameter: folder must not be empty"
 

--- a/src/read_no_evil_mcp/tools/move_email.py
+++ b/src/read_no_evil_mcp/tools/move_email.py
@@ -9,7 +9,7 @@ from read_no_evil_mcp.tools._update_notice import append_update_notice
 @mcp.tool
 @append_update_notice
 @handle_tool_errors
-def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
+def move_email(account: str, folder: str, uid: str, target_folder: str) -> str:
     """Move an email to a target folder.
 
     Args:
@@ -18,8 +18,8 @@ def move_email(account: str, folder: str, uid: int, target_folder: str) -> str:
         uid: Unique identifier of the email.
         target_folder: Destination folder to move the email to.
     """
-    if uid < 1:
-        return "Invalid parameter: uid must be a positive integer"
+    if not uid or not uid.strip():
+        return "Invalid parameter: uid must not be empty"
     if not folder or not folder.strip():
         return "Invalid parameter: folder must not be empty"
     if not target_folder or not target_folder.strip():

--- a/tests/email/connectors/test_imap.py
+++ b/tests/email/connectors/test_imap.py
@@ -105,7 +105,7 @@ class TestIMAPConnector:
         emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7))
 
         assert len(emails) == 1
-        assert emails[0].uid == 123
+        assert emails[0].uid == "123"
         assert emails[0].subject == "Test Subject"
         assert emails[0].sender.address == "sender@example.com"
         assert emails[0].is_seen is True
@@ -258,10 +258,10 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        email = connector.get_email("INBOX", 123)
+        email = connector.get_email("INBOX", "123")
 
         assert email is not None
-        assert email.uid == 123
+        assert email.uid == "123"
         assert email.body_plain == "Plain text body"
         assert email.body_html == "<p>HTML body</p>"
         assert len(email.to) == 1
@@ -296,7 +296,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        email = connector.get_email("INBOX", 123)
+        email = connector.get_email("INBOX", "123")
 
         assert email is not None
         assert email.is_seen is False
@@ -309,14 +309,14 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        email = connector.get_email("INBOX", 999)
+        email = connector.get_email("INBOX", "999")
 
         assert email is None
 
     def test_get_email_not_connected(self, config: IMAPConfig) -> None:
         connector = IMAPConnector(config)
         with pytest.raises(RuntimeError, match="Not connected"):
-            connector.get_email("INBOX", 123)
+            connector.get_email("INBOX", "123")
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_fetch_emails_skips_none_uid(
@@ -354,7 +354,7 @@ class TestIMAPConnector:
             emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7))
 
         assert len(emails) == 1
-        assert emails[0].uid == 456
+        assert emails[0].uid == "456"
         assert emails[0].subject == "Valid Email"
         assert "Skipping email with missing UID" in caplog.text
 
@@ -423,7 +423,7 @@ class TestIMAPConnector:
         connector = IMAPConnector(config)
         connector.connect()
         with caplog.at_level(logging.WARNING, logger="read_no_evil_mcp.email.connectors.imap"):
-            email = connector.get_email("INBOX", 123)
+            email = connector.get_email("INBOX", "123")
 
         assert email is None
         assert "Skipping email with missing UID" in caplog.text
@@ -441,7 +441,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.move_email("INBOX", 123, "Archive")
+        result = connector.move_email("INBOX", "123", "Archive")
 
         assert result is True
         mock_mailbox.folder.set.assert_called_with("INBOX")
@@ -463,7 +463,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.move_email("INBOX", 456, "Spam")
+        result = connector.move_email("INBOX", "456", "Spam")
 
         assert result is True
         mock_mailbox.move.assert_called_once_with("456", "Spam")
@@ -483,7 +483,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.move_email("INBOX", 789, "Important")
+        result = connector.move_email("INBOX", "789", "Important")
 
         assert result is True
         mock_mailbox.move.assert_called_once_with("789", "Important")
@@ -499,7 +499,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.move_email("INBOX", 999, "Archive")
+        result = connector.move_email("INBOX", "999", "Archive")
 
         assert result is False
         mock_mailbox.move.assert_not_called()
@@ -508,7 +508,7 @@ class TestIMAPConnector:
         """Test move_email raises RuntimeError when not connected."""
         connector = IMAPConnector(config)
         with pytest.raises(RuntimeError, match="Not connected"):
-            connector.move_email("INBOX", 123, "Archive")
+            connector.move_email("INBOX", "123", "Archive")
 
     @patch("read_no_evil_mcp.email.connectors.imap.MailBox")
     def test_delete_email(self, mock_mailbox_class: MagicMock, config: IMAPConfig) -> None:
@@ -517,7 +517,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.delete_email("INBOX", 123)
+        result = connector.delete_email("INBOX", "123")
 
         assert result is True
         mock_mailbox.folder.set.assert_called_with("INBOX")
@@ -533,7 +533,7 @@ class TestIMAPConnector:
 
         connector = IMAPConnector(config)
         connector.connect()
-        result = connector.delete_email("Sent", 456)
+        result = connector.delete_email("Sent", "456")
 
         assert result is True
         mock_mailbox.folder.set.assert_called_with("Sent")
@@ -543,7 +543,7 @@ class TestIMAPConnector:
     def test_delete_email_not_connected(self, config: IMAPConfig) -> None:
         connector = IMAPConnector(config)
         with pytest.raises(RuntimeError, match="Not connected"):
-            connector.delete_email("INBOX", 123)
+            connector.delete_email("INBOX", "123")
 
 
 class TestIMAPConnectorWithSMTP:

--- a/tests/email/test_models.py
+++ b/tests/email/test_models.py
@@ -16,7 +16,7 @@ from read_no_evil_mcp.email.models import (
 class TestEmailSummaryGetScannableContent:
     def test_returns_subject_and_sender_address(self) -> None:
         summary = EmailSummary(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Hello world",
             sender=EmailAddress(address="alice@example.com"),
@@ -32,7 +32,7 @@ class TestEmailSummaryGetScannableContent:
 
     def test_includes_sender_name_when_present(self) -> None:
         summary = EmailSummary(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Hello",
             sender=EmailAddress(name="Alice Smith", address="alice@example.com"),
@@ -49,7 +49,7 @@ class TestEmailSummaryGetScannableContent:
 
     def test_excludes_sender_name_when_none(self) -> None:
         summary = EmailSummary(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Test",
             sender=EmailAddress(name=None, address="bob@example.com"),
@@ -64,7 +64,7 @@ class TestEmailSummaryGetScannableContent:
 class TestEmailGetScannableContent:
     def test_includes_summary_fields_and_body_plain(self) -> None:
         email = Email(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Meeting",
             sender=EmailAddress(name="Boss", address="boss@example.com"),
@@ -83,7 +83,7 @@ class TestEmailGetScannableContent:
 
     def test_includes_body_html_when_present(self) -> None:
         email = Email(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Newsletter",
             sender=EmailAddress(address="news@example.com"),
@@ -101,7 +101,7 @@ class TestEmailGetScannableContent:
 
     def test_includes_attachment_filenames(self) -> None:
         email = Email(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Files",
             sender=EmailAddress(address="sender@example.com"),
@@ -123,7 +123,7 @@ class TestEmailGetScannableContent:
 
     def test_no_body_keys_when_body_is_none(self) -> None:
         email = Email(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Empty",
             sender=EmailAddress(address="sender@example.com"),
@@ -139,7 +139,7 @@ class TestEmailGetScannableContent:
 
     def test_no_attachment_keys_when_no_attachments(self) -> None:
         email = Email(
-            uid=1,
+            uid="1",
             folder="INBOX",
             subject="Plain",
             sender=EmailAddress(address="sender@example.com"),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -195,19 +195,19 @@ class TestOutgoingAttachment:
 class TestEmailSummary:
     def test_basic(self):
         summary = EmailSummary(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test Email",
             sender=EmailAddress(address="sender@example.com"),
             date=datetime(2026, 2, 3, 12, 0, 0),
         )
-        assert summary.uid == 123
+        assert summary.uid == "123"
         assert summary.has_attachments is False
         assert summary.is_seen is False
 
     def test_with_attachments(self):
         summary = EmailSummary(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test",
             sender=EmailAddress(address="sender@example.com"),
@@ -218,7 +218,7 @@ class TestEmailSummary:
 
     def test_is_seen_default_false(self):
         summary = EmailSummary(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test",
             sender=EmailAddress(address="sender@example.com"),
@@ -228,7 +228,7 @@ class TestEmailSummary:
 
     def test_is_seen_explicit_true(self):
         summary = EmailSummary(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test",
             sender=EmailAddress(address="sender@example.com"),
@@ -241,14 +241,14 @@ class TestEmailSummary:
 class TestEmail:
     def test_extends_summary(self):
         email = Email(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test Email",
             sender=EmailAddress(address="sender@example.com"),
             date=datetime(2026, 2, 3, 12, 0, 0),
             body_plain="Hello, World!",
         )
-        assert email.uid == 123
+        assert email.uid == "123"
         assert email.body_plain == "Hello, World!"
         assert email.body_html is None
         assert email.attachments == []
@@ -256,7 +256,7 @@ class TestEmail:
 
     def test_full_email(self):
         email = Email(
-            uid=456,
+            uid="456",
             folder="INBOX",
             subject="Full Email",
             sender=EmailAddress(name="Sender", address="sender@example.com"),
@@ -275,7 +275,7 @@ class TestEmail:
 
     def test_is_seen_inherited(self):
         email = Email(
-            uid=123,
+            uid="123",
             folder="INBOX",
             subject="Test",
             sender=EmailAddress(address="sender@example.com"),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -131,7 +131,7 @@ class TestGetEmail:
             side_effect=AccountNotFoundError("missing"),
         ):
             result = await client.call_tool(
-                "get_email", {"account": "missing", "folder": "INBOX", "uid": 1}
+                "get_email", {"account": "missing", "folder": "INBOX", "uid": "1"}
             )
         assert "Account not found" in result.data
 
@@ -169,7 +169,7 @@ class TestMoveEmail:
                 {
                     "account": "gone",
                     "folder": "INBOX",
-                    "uid": 1,
+                    "uid": "1",
                     "target_folder": "Archive",
                 },
             )
@@ -184,7 +184,7 @@ class TestDeleteEmail:
             side_effect=AccountNotFoundError("gone"),
         ):
             result = await client.call_tool(
-                "delete_email", {"account": "gone", "folder": "INBOX", "uid": 1}
+                "delete_email", {"account": "gone", "folder": "INBOX", "uid": "1"}
             )
         assert "Account not found" in result.data
 

--- a/tests/tools/test_delete_email.py
+++ b/tests/tools/test_delete_email.py
@@ -18,10 +18,10 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = delete_email.fn(account="work", folder="INBOX", uid=123)
+            result = delete_email.fn(account="work", folder="INBOX", uid="123")
 
         assert result == "Successfully deleted email INBOX/123"
-        mock_mailbox.delete_email.assert_called_once_with("INBOX", 123)
+        mock_mailbox.delete_email.assert_called_once_with("INBOX", "123")
 
     def test_delete_fails(self) -> None:
         """Test delete_email returns failure message when deletion fails."""
@@ -34,7 +34,7 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = delete_email.fn(account="work", folder="INBOX", uid=123)
+            result = delete_email.fn(account="work", folder="INBOX", uid="123")
 
         assert result == "Failed to delete email INBOX/123"
 
@@ -49,7 +49,7 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ) as mock_create:
-            delete_email.fn(account="personal", folder="INBOX", uid=1)
+            delete_email.fn(account="personal", folder="INBOX", uid="1")
 
         mock_create.assert_called_once_with("personal")
 
@@ -66,7 +66,7 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = delete_email.fn(account="restricted", folder="INBOX", uid=1)
+            result = delete_email.fn(account="restricted", folder="INBOX", uid="1")
 
         assert result == "Permission denied: Delete access denied for this account"
 
@@ -83,7 +83,7 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = delete_email.fn(account="restricted", folder="Secret", uid=1)
+            result = delete_email.fn(account="restricted", folder="Secret", uid="1")
 
         assert result == "Permission denied: Access to folder 'Secret' denied"
 
@@ -98,25 +98,25 @@ class TestDeleteEmail:
             "read_no_evil_mcp.tools.delete_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = delete_email.fn(account="work", folder="Sent", uid=456)
+            result = delete_email.fn(account="work", folder="Sent", uid="456")
 
         assert result == "Successfully deleted email Sent/456"
-        mock_mailbox.delete_email.assert_called_once_with("Sent", 456)
+        mock_mailbox.delete_email.assert_called_once_with("Sent", "456")
 
 
 class TestDeleteEmailValidation:
-    def test_uid_zero_rejected(self) -> None:
-        result = delete_email.fn(account="work", folder="INBOX", uid=0)
-        assert result == "Invalid parameter: uid must be a positive integer"
+    def test_empty_uid_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="INBOX", uid="")
+        assert result == "Invalid parameter: uid must not be empty"
 
-    def test_uid_negative_rejected(self) -> None:
-        result = delete_email.fn(account="work", folder="INBOX", uid=-5)
-        assert result == "Invalid parameter: uid must be a positive integer"
+    def test_whitespace_uid_rejected(self) -> None:
+        result = delete_email.fn(account="work", folder="INBOX", uid="   ")
+        assert result == "Invalid parameter: uid must not be empty"
 
     def test_empty_folder_rejected(self) -> None:
-        result = delete_email.fn(account="work", folder="", uid=1)
+        result = delete_email.fn(account="work", folder="", uid="1")
         assert result == "Invalid parameter: folder must not be empty"
 
     def test_whitespace_folder_rejected(self) -> None:
-        result = delete_email.fn(account="work", folder="  ", uid=1)
+        result = delete_email.fn(account="work", folder="  ", uid="1")
         assert result == "Invalid parameter: folder must not be empty"

--- a/tests/tools/test_get_email.py
+++ b/tests/tools/test_get_email.py
@@ -11,7 +11,7 @@ from read_no_evil_mcp.tools.get_email import get_email
 
 
 def _create_secure_email(
-    uid: int = 123,
+    uid: str = "123",
     subject: str = "Test Email",
     sender: str = "sender@example.com",
     sender_name: str | None = None,
@@ -64,7 +64,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert lines[0] == "Subject: Test Email"
@@ -85,7 +85,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert lines[4] == "Status: Unread"
@@ -98,7 +98,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=999)
+            result = get_email.fn(account="work", folder="INBOX", uid="999")
 
         assert result == "Email not found: INBOX/999"
 
@@ -115,7 +115,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         # Body section starts after blank line separator
@@ -132,14 +132,14 @@ class TestGetEmail:
             detected_patterns=["ignore_instructions", "you_are_now"],
         )
         mock_mailbox.get_email.side_effect = PromptInjectionError(
-            scan_result, email_uid=123, folder="INBOX"
+            scan_result, email_uid="123", folder="INBOX"
         )
 
         with patch(
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert lines[0] == "BLOCKED: Email INBOX/123 contains suspected prompt injection."
@@ -155,14 +155,14 @@ class TestGetEmail:
             detected_patterns=["system_tag"],
         )
         mock_mailbox.get_email.side_effect = PromptInjectionError(
-            scan_result, email_uid=456, folder="Sent"
+            scan_result, email_uid="456", folder="Sent"
         )
 
         with patch(
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="Sent", uid=456)
+            result = get_email.fn(account="work", folder="Sent", uid="456")
 
         lines = result.split("\n")
         assert lines[0] == "BLOCKED: Email Sent/456 contains suspected prompt injection."
@@ -177,7 +177,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ) as mock_create:
-            get_email.fn(account="personal", folder="INBOX", uid=1)
+            get_email.fn(account="personal", folder="INBOX", uid="1")
 
         mock_create.assert_called_once_with("personal")
 
@@ -192,7 +192,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="restricted", folder="INBOX", uid=1)
+            result = get_email.fn(account="restricted", folder="INBOX", uid="1")
 
         assert result == "Permission denied: Read access denied for this account"
 
@@ -207,7 +207,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="restricted", folder="Secret", uid=1)
+            result = get_email.fn(account="restricted", folder="Secret", uid="1")
 
         assert result == "Permission denied: Access to folder 'Secret' denied"
 
@@ -226,7 +226,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert "Access: TRUSTED" in lines
@@ -247,7 +247,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert "Access: ASK_BEFORE_READ" in lines
@@ -268,7 +268,7 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert not any(line.startswith("Access:") for line in lines)
@@ -289,27 +289,27 @@ class TestGetEmail:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert "-> Custom trusted read prompt here" in lines
 
 
 class TestGetEmailValidation:
-    def test_uid_zero_rejected(self) -> None:
-        result = get_email.fn(account="work", folder="INBOX", uid=0)
-        assert result == "Invalid parameter: uid must be a positive integer"
+    def test_empty_uid_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="INBOX", uid="")
+        assert result == "Invalid parameter: uid must not be empty"
 
-    def test_uid_negative_rejected(self) -> None:
-        result = get_email.fn(account="work", folder="INBOX", uid=-1)
-        assert result == "Invalid parameter: uid must be a positive integer"
+    def test_whitespace_uid_rejected(self) -> None:
+        result = get_email.fn(account="work", folder="INBOX", uid="   ")
+        assert result == "Invalid parameter: uid must not be empty"
 
     def test_empty_folder_rejected(self) -> None:
-        result = get_email.fn(account="work", folder="", uid=1)
+        result = get_email.fn(account="work", folder="", uid="1")
         assert result == "Invalid parameter: folder must not be empty"
 
     def test_whitespace_folder_rejected(self) -> None:
-        result = get_email.fn(account="work", folder="   ", uid=1)
+        result = get_email.fn(account="work", folder="   ", uid="1")
         assert result == "Invalid parameter: folder must not be empty"
 
 
@@ -328,7 +328,7 @@ class TestGetEmailProtectionSkipped:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert "Protection: SKIPPED" in lines
@@ -347,7 +347,7 @@ class TestGetEmailProtectionSkipped:
             "read_no_evil_mcp.tools.get_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = get_email.fn(account="work", folder="INBOX", uid=123)
+            result = get_email.fn(account="work", folder="INBOX", uid="123")
 
         lines = result.split("\n")
         assert "Protection: SKIPPED" not in lines

--- a/tests/tools/test_list_emails.py
+++ b/tests/tools/test_list_emails.py
@@ -12,7 +12,7 @@ from read_no_evil_mcp.tools.list_emails import list_emails
 
 
 def _create_secure_summary(
-    uid: int = 1,
+    uid: str = "1",
     subject: str = "Test Subject",
     sender: str = "sender@example.com",
     access_level: AccessLevel = AccessLevel.SHOW,
@@ -63,7 +63,7 @@ class TestListEmails:
     def test_returns_email_summaries(self) -> None:
         """Test list_emails tool returns email summaries."""
         secure_emails = [
-            _create_secure_summary(uid=1, subject="Test Subject", has_attachments=True)
+            _create_secure_summary(uid="1", subject="Test Subject", has_attachments=True)
         ]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails)
 
@@ -280,7 +280,7 @@ class TestListEmails:
 class TestListEmailsPagination:
     def test_pagination_message_when_more_results(self) -> None:
         """Test that pagination message shows when there are more results."""
-        secure_emails = [_create_secure_summary(uid=1), _create_secure_summary(uid=2)]
+        secure_emails = [_create_secure_summary(uid="1"), _create_secure_summary(uid="2")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails, total=5)
 
         with patch(
@@ -293,7 +293,7 @@ class TestListEmailsPagination:
 
     def test_pagination_message_with_offset(self) -> None:
         """Test pagination message with non-zero offset."""
-        secure_emails = [_create_secure_summary(uid=3), _create_secure_summary(uid=4)]
+        secure_emails = [_create_secure_summary(uid="3"), _create_secure_summary(uid="4")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails, total=5)
 
         with patch(
@@ -306,7 +306,7 @@ class TestListEmailsPagination:
 
     def test_no_pagination_message_when_all_shown(self) -> None:
         """Test no pagination message when all results are shown."""
-        secure_emails = [_create_secure_summary(uid=1), _create_secure_summary(uid=2)]
+        secure_emails = [_create_secure_summary(uid="1"), _create_secure_summary(uid="2")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails, total=2)
 
         with patch(
@@ -391,7 +391,7 @@ class TestListEmailsValidation:
 class TestListEmailsFilterCounts:
     def test_blocked_count_shown(self) -> None:
         """Test that blocked count note is shown when emails are blocked."""
-        secure_emails = [_create_secure_summary(uid=1)]
+        secure_emails = [_create_secure_summary(uid="1")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails, blocked_count=3)
 
         with patch(
@@ -404,7 +404,7 @@ class TestListEmailsFilterCounts:
 
     def test_hidden_count_shown(self) -> None:
         """Test that hidden count note is shown with singular noun."""
-        secure_emails = [_create_secure_summary(uid=1)]
+        secure_emails = [_create_secure_summary(uid="1")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails, hidden_count=1)
 
         with patch(
@@ -417,7 +417,7 @@ class TestListEmailsFilterCounts:
 
     def test_both_counts_shown(self) -> None:
         """Test that both blocked and hidden counts are shown together."""
-        secure_emails = [_create_secure_summary(uid=1)]
+        secure_emails = [_create_secure_summary(uid="1")]
         mock_mailbox = _create_mock_mailbox(
             secure_emails=secure_emails, blocked_count=2, hidden_count=1
         )
@@ -432,7 +432,7 @@ class TestListEmailsFilterCounts:
 
     def test_no_filter_note_when_zero_counts(self) -> None:
         """Test that no filter note is shown when counts are zero."""
-        secure_emails = [_create_secure_summary(uid=1)]
+        secure_emails = [_create_secure_summary(uid="1")]
         mock_mailbox = _create_mock_mailbox(secure_emails=secure_emails)
 
         with patch(
@@ -445,7 +445,7 @@ class TestListEmailsFilterCounts:
 
     def test_filter_note_with_pagination(self) -> None:
         """Test that both filter note and pagination message are shown."""
-        secure_emails = [_create_secure_summary(uid=1), _create_secure_summary(uid=2)]
+        secure_emails = [_create_secure_summary(uid="1"), _create_secure_summary(uid="2")]
         mock_mailbox = _create_mock_mailbox(
             secure_emails=secure_emails, total=5, blocked_count=2, hidden_count=1
         )

--- a/tests/tools/test_move_email.py
+++ b/tests/tools/test_move_email.py
@@ -18,10 +18,12 @@ class TestMoveEmail:
             "read_no_evil_mcp.tools.move_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = move_email.fn(account="work", folder="INBOX", uid=123, target_folder="Archive")
+            result = move_email.fn(
+                account="work", folder="INBOX", uid="123", target_folder="Archive"
+            )
 
         assert result == "Email INBOX/123 moved to Archive."
-        mock_mailbox.move_email.assert_called_once_with("INBOX", 123, "Archive")
+        mock_mailbox.move_email.assert_called_once_with("INBOX", "123", "Archive")
 
     def test_moves_email_to_spam(self) -> None:
         """Test move_email tool can move email to Spam folder."""
@@ -34,10 +36,10 @@ class TestMoveEmail:
             "read_no_evil_mcp.tools.move_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = move_email.fn(account="work", folder="INBOX", uid=456, target_folder="Spam")
+            result = move_email.fn(account="work", folder="INBOX", uid="456", target_folder="Spam")
 
         assert result == "Email INBOX/456 moved to Spam."
-        mock_mailbox.move_email.assert_called_once_with("INBOX", 456, "Spam")
+        mock_mailbox.move_email.assert_called_once_with("INBOX", "456", "Spam")
 
     def test_email_not_found(self) -> None:
         """Test move_email with non-existent email."""
@@ -50,7 +52,9 @@ class TestMoveEmail:
             "read_no_evil_mcp.tools.move_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = move_email.fn(account="work", folder="INBOX", uid=999, target_folder="Archive")
+            result = move_email.fn(
+                account="work", folder="INBOX", uid="999", target_folder="Archive"
+            )
 
         assert result == "Email not found: INBOX/999"
 
@@ -68,7 +72,7 @@ class TestMoveEmail:
             return_value=mock_mailbox,
         ):
             result = move_email.fn(
-                account="restricted", folder="INBOX", uid=1, target_folder="Archive"
+                account="restricted", folder="INBOX", uid="1", target_folder="Archive"
             )
 
         assert result == "Permission denied: Move access denied for this account"
@@ -87,7 +91,7 @@ class TestMoveEmail:
             return_value=mock_mailbox,
         ):
             result = move_email.fn(
-                account="restricted", folder="Secret", uid=1, target_folder="Archive"
+                account="restricted", folder="Secret", uid="1", target_folder="Archive"
             )
 
         assert result == "Permission denied: Access to folder 'Secret' denied"
@@ -106,7 +110,7 @@ class TestMoveEmail:
             return_value=mock_mailbox,
         ):
             result = move_email.fn(
-                account="work", folder="INBOX", uid=1, target_folder="Restricted"
+                account="work", folder="INBOX", uid="1", target_folder="Restricted"
             )
 
         assert result == "Permission denied: Access to folder 'Restricted' denied"
@@ -122,7 +126,7 @@ class TestMoveEmail:
             "read_no_evil_mcp.tools.move_email.create_securemailbox",
             return_value=mock_mailbox,
         ) as mock_create:
-            move_email.fn(account="personal", folder="INBOX", uid=1, target_folder="Archive")
+            move_email.fn(account="personal", folder="INBOX", uid="1", target_folder="Archive")
 
         mock_create.assert_called_once_with("personal")
 
@@ -137,24 +141,28 @@ class TestMoveEmail:
             "read_no_evil_mcp.tools.move_email.create_securemailbox",
             return_value=mock_mailbox,
         ):
-            result = move_email.fn(account="work", folder="INBOX", uid=1, target_folder="Archive")
+            result = move_email.fn(account="work", folder="INBOX", uid="1", target_folder="Archive")
 
         assert result == "Error: Connection lost"
 
 
 class TestMoveEmailValidation:
-    def test_uid_zero_rejected(self) -> None:
-        result = move_email.fn(account="work", folder="INBOX", uid=0, target_folder="Archive")
-        assert result == "Invalid parameter: uid must be a positive integer"
+    def test_empty_uid_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="INBOX", uid="", target_folder="Archive")
+        assert result == "Invalid parameter: uid must not be empty"
+
+    def test_whitespace_uid_rejected(self) -> None:
+        result = move_email.fn(account="work", folder="INBOX", uid="   ", target_folder="Archive")
+        assert result == "Invalid parameter: uid must not be empty"
 
     def test_empty_folder_rejected(self) -> None:
-        result = move_email.fn(account="work", folder="", uid=1, target_folder="Archive")
+        result = move_email.fn(account="work", folder="", uid="1", target_folder="Archive")
         assert result == "Invalid parameter: folder must not be empty"
 
     def test_empty_target_folder_rejected(self) -> None:
-        result = move_email.fn(account="work", folder="INBOX", uid=1, target_folder="")
+        result = move_email.fn(account="work", folder="INBOX", uid="1", target_folder="")
         assert result == "Invalid parameter: target_folder must not be empty"
 
     def test_whitespace_target_folder_rejected(self) -> None:
-        result = move_email.fn(account="work", folder="INBOX", uid=1, target_folder="   ")
+        result = move_email.fn(account="work", folder="INBOX", uid="1", target_folder="   ")
         assert result == "Invalid parameter: target_folder must not be empty"


### PR DESCRIPTION
## Summary

- Changed `EmailSummary.uid` from `int` to `str` across the entire public interface to support connectors with non-numeric message IDs (e.g., Gmail API)
- Updated `BaseConnector` method signatures (`get_email`, `move_email`, `delete_email`) to accept `str` UIDs
- Simplified `IMAPConnector` by removing unnecessary `int()` conversions (imap-tools already works with string UIDs)
- Updated all MCP tool implementations with string UID validation
- Updated all tests to use string UIDs

## Test plan

- [x] All 740 existing tests pass with updated string UIDs
- [x] `ruff check`, `ruff format`, and `mypy` all pass
- [x] No functional changes — pure type refactor

Closes #284