### PR TITLE
feat: Add read-only Gmail API connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Gmail API connector for reading emails via Google OAuth2 ([#285])
 - Eager ML model preloading at server startup for predictable first-request latency ([#260])
 - `RNOE_LAZY_LOAD` environment variable to opt into lazy model loading ([#260])
 - Support email addresses as account IDs with automatic env var normalization ([#259])
@@ -135,6 +136,7 @@ Initial public release with core email gateway functionality:
 [0.3.0]: https://github.com/thekie/read-no-evil-mcp/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/thekie/read-no-evil-mcp/releases/tag/v0.2.0
 
+[#285]: https://github.com/thekie/read-no-evil-mcp/issues/285
 [#260]: https://github.com/thekie/read-no-evil-mcp/issues/260
 [#259]: https://github.com/thekie/read-no-evil-mcp/issues/259
 [#258]: https://github.com/thekie/read-no-evil-mcp/issues/258

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -434,6 +434,84 @@ export RNOE_ACCOUNT_WORK_PASSWORD="your-work-password"
 export RNOE_ACCOUNT_PERSONAL_PASSWORD="your-gmail-app-password"
 ```
 
+## Gmail API Connector
+
+Instead of IMAP, you can connect to Gmail using Google's API with OAuth2 authentication. This avoids app passwords and uses Google's official API.
+
+### Prerequisites
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a project (or select an existing one).
+3. Enable the **Gmail API** under **APIs & Services > Library**.
+4. Go to **APIs & Services > Credentials** and create an **OAuth 2.0 Client ID** (application type: **Desktop app**).
+5. Download the credentials JSON file and save it (e.g., `~/.config/read-no-evil-mcp/credentials.json`).
+
+### Configuration
+
+```yaml
+accounts:
+  - id: "gmail"
+    type: "gmail"
+    email: "you@gmail.com"
+    credentials_file: "~/.config/read-no-evil-mcp/credentials.json"
+    token_file: "~/.config/read-no-evil-mcp/gmail_token.json"
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `type` | yes | — | Must be `"gmail"` |
+| `email` | yes | — | Your Gmail address |
+| `credentials_file` | yes | — | Path to the OAuth2 client credentials JSON from Google Cloud Console |
+| `token_file` | no | `gmail_token.json` | Path where the OAuth2 token is stored after first login |
+| `from_address` | no | — | Sender address for outgoing emails (defaults to `email`) |
+| `from_name` | no | — | Display name for outgoing emails |
+
+On first run, a browser window opens for you to authorize the application. After that, the token is saved to `token_file` and reused automatically.
+
+### What works
+
+Gmail accounts support the same read operations as IMAP: listing labels (folders), fetching email summaries, and reading full emails. Prompt injection scanning works identically.
+
+Move and delete are not yet supported for Gmail accounts. Attempting them returns a "not implemented" error.
+
+### Gmail with access rules
+
+Gmail accounts support the same sender rules, subject rules, protection settings, and custom prompts as IMAP accounts:
+
+```yaml
+accounts:
+  - id: "gmail"
+    type: "gmail"
+    email: "you@gmail.com"
+    credentials_file: "~/.config/read-no-evil-mcp/credentials.json"
+    token_file: "~/.config/read-no-evil-mcp/gmail_token.json"
+    protection:
+      threshold: 0.4
+    sender_rules:
+      - pattern: "@yourcompany\\.com$"
+        access: trusted
+    permissions:
+      read: true
+      send: false
+```
+
+### IMAP vs Gmail
+
+| | IMAP (`type: "imap"`) | Gmail API (`type: "gmail"`) |
+|---|---|---|
+| Authentication | Password / app password | OAuth2 (browser login) |
+| Read emails | Yes | Yes |
+| Send emails | Yes (SMTP) | No |
+| Move/delete | Yes | No |
+| Works with | Any IMAP provider | Gmail only |
+
+Use IMAP if you need send, move, or delete. Use the Gmail connector if you prefer OAuth2 authentication or want to avoid app passwords.
+
+```bash
+export RNOE_ACCOUNT_WORK_PASSWORD="your-work-password"
+export RNOE_ACCOUNT_PERSONAL_PASSWORD="your-gmail-app-password"
+```
+
 ## Environment Variables
 
 ### Server settings

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A secure email gateway MCP server that protects AI agents from prompt injection 
      ↓
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
 │   Mailbox   │ ──► │ read-no-evil│ ──► │  AI Agent   │
-│  (IMAP)     │     │     -mcp    │     │  (Claude,   │
+│ (IMAP/Gmail)│     │     -mcp    │     │  (Claude,   │
 │             │     │   🛡️ scan   │     │   GPT, ...) │
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
@@ -44,7 +44,7 @@ The AI reads this, follows the hidden instruction, and your data is compromised.
 
 - 🛡️ **Prompt Injection Detection** — Scans emails using [ProtectAI's DeBERTa model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2)
 - 🔐 **Per-Account Permissions** — Read-only by default, restrict folders, control delete/send per account
-- 📧 **Multi-Account Support** — Configure multiple IMAP accounts with different permissions
+- 📧 **Multi-Account Support** — Configure multiple email accounts with different permissions (IMAP and Gmail API)
 - 🔌 **MCP Integration** — Exposes email tools via [Model Context Protocol](https://modelcontextprotocol.io/)
 - 🏠 **Local** — Model runs on your machine, no data sent to external APIs
 - 🪶 **CPU-only PyTorch** (~200MB) — No GPU required
@@ -502,7 +502,7 @@ To defer model loading to the first scan instead, set `RNOE_LAZY_LOAD=true`.
 ### v0.4 (Later)
 - [ ] Keyring credential backend ([#45](https://github.com/thekie/read-no-evil-mcp/issues/45))
 - [ ] Attachment scanning
-- [ ] Gmail API connector
+- [x] Gmail API connector ([#285](https://github.com/thekie/read-no-evil-mcp/issues/285))
 - [ ] Microsoft Graph connector
 - [ ] Improved obfuscation detection
 
@@ -514,7 +514,7 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for dev setup, testing, and PR workfl
 
 - **Add test cases** — Edit a YAML file, no Python required! See [payloads/README.md](tests/integration/prompt_injection/payloads/README.md)
 - **Improve detection** — Check [DETECTION_MATRIX.md](DETECTION_MATRIX.md) for techniques we miss (❌)
-- **Add connectors** — Gmail API, Microsoft Graph — PRs welcome!
+- **Add connectors** — Microsoft Graph, other providers — PRs welcome!
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "transformers>=4.30,<6.0",
     "torch>=2.0,<3.0",
     "imap-tools",
+    "google-api-python-client>=2.0",
+    "google-auth-oauthlib>=1.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
@@ -76,6 +78,10 @@ module = [
     "transformers.*",
     "optimum.*",
     "pydantic_settings.*",
+    "googleapiclient.*",
+    "google.oauth2.*",
+    "google.auth.*",
+    "google_auth_oauthlib.*",
 ]
 ignore_missing_imports = true
 

--- a/src/read_no_evil_mcp/accounts/__init__.py
+++ b/src/read_no_evil_mcp/accounts/__init__.py
@@ -3,6 +3,7 @@
 from read_no_evil_mcp.accounts.config import (
     AccountConfig,
     BaseAccountConfig,
+    GmailAccountConfig,
     IMAPAccountConfig,
 )
 from read_no_evil_mcp.accounts.credentials import CredentialBackend, EnvCredentialBackend
@@ -16,5 +17,6 @@ __all__ = [
     "BaseAccountConfig",
     "CredentialBackend",
     "EnvCredentialBackend",
+    "GmailAccountConfig",
     "IMAPAccountConfig",
 ]

--- a/src/read_no_evil_mcp/email/__init__.py
+++ b/src/read_no_evil_mcp/email/__init__.py
@@ -1,7 +1,8 @@
 """Email connectors and models for read-no-evil-mcp."""
 
 from read_no_evil_mcp.email.connectors.base import BaseConnector
-from read_no_evil_mcp.email.connectors.config import IMAPConfig, SMTPConfig
+from read_no_evil_mcp.email.connectors.config import GmailConfig, IMAPConfig, SMTPConfig
+from read_no_evil_mcp.email.connectors.gmail import GmailConnector
 from read_no_evil_mcp.email.connectors.imap import IMAPConnector
 from read_no_evil_mcp.email.models import (
     Attachment,
@@ -18,6 +19,8 @@ __all__ = [
     "EmailAddress",
     "EmailSummary",
     "Folder",
+    "GmailConfig",
+    "GmailConnector",
     "IMAPConfig",
     "IMAPConnector",
     "SMTPConfig",

--- a/src/read_no_evil_mcp/email/connectors/__init__.py
+++ b/src/read_no_evil_mcp/email/connectors/__init__.py
@@ -1,7 +1,15 @@
 """Email connectors for read-no-evil-mcp."""
 
 from read_no_evil_mcp.email.connectors.base import BaseConnector
-from read_no_evil_mcp.email.connectors.config import IMAPConfig, SMTPConfig
+from read_no_evil_mcp.email.connectors.config import GmailConfig, IMAPConfig, SMTPConfig
+from read_no_evil_mcp.email.connectors.gmail import GmailConnector
 from read_no_evil_mcp.email.connectors.imap import IMAPConnector
 
-__all__ = ["BaseConnector", "IMAPConfig", "IMAPConnector", "SMTPConfig"]
+__all__ = [
+    "BaseConnector",
+    "GmailConfig",
+    "GmailConnector",
+    "IMAPConfig",
+    "IMAPConnector",
+    "SMTPConfig",
+]

--- a/src/read_no_evil_mcp/email/connectors/config.py
+++ b/src/read_no_evil_mcp/email/connectors/config.py
@@ -22,3 +22,10 @@ class SMTPConfig(BaseModel):
     username: str
     password: SecretStr
     ssl: bool = False  # False = use STARTTLS, True = use SSL
+
+
+class GmailConfig(BaseModel):
+    """Gmail API configuration."""
+
+    credentials_file: str
+    token_file: str

--- a/src/read_no_evil_mcp/email/connectors/gmail.py
+++ b/src/read_no_evil_mcp/email/connectors/gmail.py
@@ -1,0 +1,313 @@
+"""Gmail API connector for reading emails."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import os
+from datetime import date, datetime, timedelta, timezone
+from email.utils import parseaddr, parsedate_to_datetime
+from typing import Any
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+from read_no_evil_mcp.email.connectors.base import BaseConnector
+from read_no_evil_mcp.email.connectors.config import GmailConfig
+from read_no_evil_mcp.email.models import (
+    Attachment,
+    Email,
+    EmailAddress,
+    EmailSummary,
+    Folder,
+)
+
+logger = logging.getLogger(__name__)
+
+_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+_DEFAULT_SENDER = EmailAddress(address="unknown@unknown")
+
+
+def _parse_address(raw: str) -> EmailAddress:
+    """Parse an RFC 2822 address string into an EmailAddress."""
+    name, addr = parseaddr(raw)
+    if not addr:
+        return _DEFAULT_SENDER
+    return EmailAddress(name=name or None, address=addr)
+
+
+def _parse_address_list(raw: str) -> list[EmailAddress]:
+    """Parse a comma-separated address header into a list of EmailAddress."""
+    if not raw:
+        return []
+    results = []
+    for part in raw.split(","):
+        part = part.strip()
+        if part:
+            parsed = _parse_address(part)
+            if parsed.address != "unknown@unknown":
+                results.append(parsed)
+    return results
+
+
+def _get_header(headers: list[dict[str, str]], name: str) -> str:
+    """Get a header value by name (case-insensitive)."""
+    lower_name = name.lower()
+    for h in headers:
+        if h["name"].lower() == lower_name:
+            return h["value"]
+    return ""
+
+
+def _parse_date(date_str: str) -> datetime:
+    """Parse an RFC 2822 date string into a datetime."""
+    try:
+        return parsedate_to_datetime(date_str)
+    except Exception:
+        return datetime.now(timezone.utc)
+
+
+def _extract_body_parts(
+    payload: dict[str, object],
+) -> tuple[str | None, str | None, list[Attachment]]:
+    """Recursively extract text/plain, text/html bodies and attachment metadata."""
+    plain: str | None = None
+    html: str | None = None
+    attachments: list[Attachment] = []
+
+    mime_type = str(payload.get("mimeType", ""))
+    filename = str(payload.get("filename", ""))
+    body = payload.get("body")
+    body_dict = body if isinstance(body, dict) else {}
+    parts = payload.get("parts")
+    parts_list: list[dict[str, object]] = parts if isinstance(parts, list) else []
+
+    # If this part is an attachment (has filename and size > 0)
+    if filename:
+        size = body_dict.get("size")
+        attachments.append(
+            Attachment(
+                filename=filename,
+                content_type=mime_type or "application/octet-stream",
+                size=int(size) if isinstance(size, int) else None,
+            )
+        )
+    elif parts_list:
+        # Recurse into multipart
+        for part in parts_list:
+            p, h, atts = _extract_body_parts(part)
+            if p and not plain:
+                plain = p
+            if h and not html:
+                html = h
+            attachments.extend(atts)
+    else:
+        # Leaf node with body data
+        data = body_dict.get("data")
+        if isinstance(data, str) and data:
+            try:
+                decoded = base64.urlsafe_b64decode(data).decode("utf-8", errors="replace")
+            except binascii.Error:
+                logger.warning("Skipping body part with malformed base64 data")
+                return plain, html, attachments
+            if mime_type == "text/plain" and not plain:
+                plain = decoded
+            elif mime_type == "text/html" and not html:
+                html = decoded
+
+    return plain, html, attachments
+
+
+class GmailConnector(BaseConnector):
+    """Connector for reading emails via the Gmail API."""
+
+    def __init__(self, config: GmailConfig) -> None:
+        self.config = config
+        self._service: Any = None
+        self._creds: Credentials | None = None
+
+    def connect(self) -> None:
+        """Authenticate with Gmail API and build the service."""
+        creds: Credentials | None = None
+
+        # Try loading existing token
+        try:
+            creds = Credentials.from_authorized_user_file(  # type: ignore[no-untyped-call]
+                self.config.token_file, _SCOPES
+            )
+        except (FileNotFoundError, ValueError):
+            pass
+
+        # Refresh or run OAuth flow
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        elif not creds or not creds.valid:
+            flow = InstalledAppFlow.from_client_secrets_file(self.config.credentials_file, _SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # Save token with restrictive permissions (owner-only read/write)
+        fd = os.open(self.config.token_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(creds.to_json())
+
+        self._creds = creds
+        self._service = build("gmail", "v1", credentials=creds)
+
+    def disconnect(self) -> None:
+        """Close the Gmail API service."""
+        self._service = None
+        self._creds = None
+
+    def _get_service(self) -> Any:
+        if not self._service:
+            raise RuntimeError("Not connected. Call connect() first.")
+        return self._service
+
+    def list_folders(self) -> list[Folder]:
+        """List Gmail labels as folders."""
+        service = self._get_service()
+        results = service.users().labels().list(userId="me").execute()
+        labels: list[dict[str, str]] = results.get("labels", [])
+
+        folders = []
+        for label in labels:
+            folders.append(
+                Folder(
+                    name=label["id"],
+                    delimiter="/",
+                    flags=[label.get("type", "user")],
+                )
+            )
+        return folders
+
+    def fetch_emails(
+        self,
+        folder: str = "INBOX",
+        *,
+        lookback: timedelta,
+        from_date: date | None = None,
+        limit: int | None = None,
+        unread_only: bool = False,
+    ) -> list[EmailSummary]:
+        """Fetch email summaries from a Gmail label."""
+        service = self._get_service()
+
+        end_date = from_date or date.today()
+        start_date = end_date - lookback
+
+        # Build Gmail search query
+        query_parts = [
+            f"after:{start_date.strftime('%Y/%m/%d')}",
+            f"before:{(end_date + timedelta(days=1)).strftime('%Y/%m/%d')}",
+        ]
+        if unread_only:
+            query_parts.append("is:unread")
+        query = " ".join(query_parts)
+
+        max_results = limit or 100
+
+        response = (
+            service.users()
+            .messages()
+            .list(userId="me", labelIds=[folder], q=query, maxResults=max_results)
+            .execute()
+        )
+        messages: list[dict[str, str]] = response.get("messages", [])
+
+        summaries = []
+        for msg_ref in messages:
+            msg = (
+                service.users()
+                .messages()
+                .get(
+                    userId="me",
+                    id=msg_ref["id"],
+                    format="metadata",
+                    metadataHeaders=["From", "Subject", "Date"],
+                )
+                .execute()
+            )
+
+            headers: list[dict[str, str]] = msg.get("payload", {}).get("headers", [])
+            label_ids: list[str] = msg.get("labelIds", [])
+
+            sender = _parse_address(_get_header(headers, "From"))
+            subject = _get_header(headers, "Subject") or "(no subject)"
+            date_str = _get_header(headers, "Date")
+            msg_date = _parse_date(date_str) if date_str else datetime.now(timezone.utc)
+
+            # Gmail uses UNREAD label instead of \Seen flag
+            is_seen = "UNREAD" not in label_ids
+
+            summaries.append(
+                EmailSummary(
+                    uid=msg["id"],
+                    folder=folder,
+                    subject=subject,
+                    sender=sender,
+                    date=msg_date,
+                    # Metadata format doesn't include parts; get_email() detects attachments
+                    has_attachments=False,
+                    is_seen=is_seen,
+                )
+            )
+
+            if limit and len(summaries) >= limit:
+                break
+
+        return summaries
+
+    def get_email(self, folder: str, uid: str) -> Email | None:
+        """Fetch full email content by message ID."""
+        service = self._get_service()
+
+        try:
+            msg = service.users().messages().get(userId="me", id=uid, format="full").execute()
+        except Exception:
+            logger.warning("Failed to fetch Gmail message (id=%s)", uid)
+            return None
+
+        payload: dict[str, object] = msg.get("payload", {})
+        headers: list[dict[str, str]] = payload.get("headers", [])  # type: ignore[assignment]
+        label_ids: list[str] = msg.get("labelIds", [])
+
+        sender = _parse_address(_get_header(headers, "From"))
+        subject = _get_header(headers, "Subject") or "(no subject)"
+        date_str = _get_header(headers, "Date")
+        msg_date = _parse_date(date_str) if date_str else datetime.now(timezone.utc)
+
+        to = _parse_address_list(_get_header(headers, "To"))
+        cc = _parse_address_list(_get_header(headers, "Cc"))
+        message_id = _get_header(headers, "Message-ID") or None
+
+        plain, html, attachments = _extract_body_parts(payload)
+
+        is_seen = "UNREAD" not in label_ids
+
+        return Email(
+            uid=msg["id"],
+            folder=folder,
+            subject=subject,
+            sender=sender,
+            date=msg_date,
+            has_attachments=len(attachments) > 0,
+            is_seen=is_seen,
+            to=to,
+            cc=cc,
+            body_plain=plain,
+            body_html=html,
+            attachments=attachments,
+            message_id=message_id,
+        )
+
+    def move_email(self, folder: str, uid: str, target_folder: str) -> bool:
+        """Not implemented for Gmail connector."""
+        raise NotImplementedError("GmailConnector does not support move_email")
+
+    def delete_email(self, folder: str, uid: str) -> bool:
+        """Not implemented for Gmail connector."""
+        raise NotImplementedError("GmailConnector does not support delete_email")

--- a/src/read_no_evil_mcp/models.py
+++ b/src/read_no_evil_mcp/models.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from read_no_evil_mcp.accounts.config import AccessLevel
 
 # Re-export for backwards compatibility
-from read_no_evil_mcp.email.connectors.config import IMAPConfig, SMTPConfig
+from read_no_evil_mcp.email.connectors.config import GmailConfig, IMAPConfig, SMTPConfig
 from read_no_evil_mcp.email.models import (
     Attachment,
     Email,
@@ -31,6 +31,7 @@ __all__ = [
     "EmailAddress",
     "EmailSummary",
     "Folder",
+    "GmailConfig",
     "IMAPConfig",
     "OutgoingAttachment",
     "ScanResult",

--- a/tests/accounts/test_config.py
+++ b/tests/accounts/test_config.py
@@ -8,6 +8,7 @@ from read_no_evil_mcp.accounts.config import (
     AccessLevel,
     AccountConfig,
     BaseAccountConfig,
+    GmailAccountConfig,
     IMAPAccountConfig,
     SenderRule,
     SubjectRule,
@@ -18,7 +19,7 @@ from read_no_evil_mcp.protection.models import ProtectionConfig
 class TestAccountConfig:
     def test_valid_config(self) -> None:
         """Test valid account configuration."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             type="imap",
             host="mail.example.com",
@@ -32,7 +33,7 @@ class TestAccountConfig:
 
     def test_custom_port(self) -> None:
         """Test account configuration with custom port."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             port=143,
@@ -45,7 +46,7 @@ class TestAccountConfig:
     def test_id_validation_starts_with_letter(self) -> None:
         """Test that ID must start with a letter."""
         with pytest.raises(ValidationError) as exc_info:
-            AccountConfig(
+            IMAPAccountConfig(
                 id="123invalid",
                 host="mail.example.com",
                 username="user@example.com",
@@ -54,7 +55,7 @@ class TestAccountConfig:
 
     def test_id_validation_allows_hyphens_underscores(self) -> None:
         """Test that ID allows hyphens and underscores."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="my-work_email",
             host="mail.example.com",
             username="user@example.com",
@@ -63,7 +64,7 @@ class TestAccountConfig:
 
     def test_id_validation_allows_email_address(self) -> None:
         """Test that ID accepts an email address like user@example.com."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="user@example.com",
             host="mail.example.com",
             username="user@example.com",
@@ -72,7 +73,7 @@ class TestAccountConfig:
 
     def test_id_validation_allows_email_with_dots(self) -> None:
         """Test that ID accepts an email with dots in local part."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="john.doe@example.com",
             host="mail.example.com",
             username="john.doe@example.com",
@@ -81,7 +82,7 @@ class TestAccountConfig:
 
     def test_id_validation_allows_email_with_subdomains(self) -> None:
         """Test that ID accepts an email with subdomains."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="user@mail.company.co.uk",
             host="mail.company.co.uk",
             username="user@mail.company.co.uk",
@@ -91,7 +92,7 @@ class TestAccountConfig:
     def test_id_validation_empty(self) -> None:
         """Test that ID cannot be empty."""
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="",
                 host="mail.example.com",
                 username="user@example.com",
@@ -100,7 +101,7 @@ class TestAccountConfig:
     def test_host_required(self) -> None:
         """Test that host is required."""
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="work",
                 username="user@example.com",
             )  # type: ignore[call-arg]
@@ -108,7 +109,7 @@ class TestAccountConfig:
     def test_username_required(self) -> None:
         """Test that username is required."""
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="work",
                 host="mail.example.com",
             )  # type: ignore[call-arg]
@@ -116,7 +117,7 @@ class TestAccountConfig:
     def test_port_validation(self) -> None:
         """Test port validation (1-65535)."""
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="work",
                 host="mail.example.com",
                 port=0,
@@ -124,7 +125,7 @@ class TestAccountConfig:
             )
 
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="work",
                 host="mail.example.com",
                 port=70000,
@@ -133,7 +134,7 @@ class TestAccountConfig:
 
     def test_from_address_and_from_name(self) -> None:
         """Test from_address and from_name fields."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -145,7 +146,7 @@ class TestAccountConfig:
 
     def test_from_address_without_from_name(self) -> None:
         """Test from_address without from_name."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -156,7 +157,7 @@ class TestAccountConfig:
 
     def test_from_address_defaults_to_none(self) -> None:
         """Test that from_address defaults to None."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -165,7 +166,7 @@ class TestAccountConfig:
         assert config.from_name is None
 
     def test_sent_folder_defaults_to_sent(self) -> None:
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -173,7 +174,7 @@ class TestAccountConfig:
         assert config.sent_folder == "Sent"
 
     def test_sent_folder_custom(self) -> None:
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -182,7 +183,7 @@ class TestAccountConfig:
         assert config.sent_folder == "[Gmail]/Sent Mail"
 
     def test_sent_folder_disabled(self) -> None:
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -193,7 +194,7 @@ class TestAccountConfig:
     def test_from_address_cannot_be_empty(self) -> None:
         """Test that from_address cannot be empty string."""
         with pytest.raises(ValidationError):
-            AccountConfig(
+            IMAPAccountConfig(
                 id="work",
                 host="mail.example.com",
                 username="user",
@@ -202,7 +203,7 @@ class TestAccountConfig:
 
     def test_protection_defaults_to_none(self) -> None:
         """Test that protection defaults to None."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user@example.com",
@@ -211,7 +212,7 @@ class TestAccountConfig:
 
     def test_protection_with_custom_threshold(self) -> None:
         """Test that protection accepts a ProtectionConfig with custom threshold."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user@example.com",
@@ -222,7 +223,7 @@ class TestAccountConfig:
 
     def test_sender_rules_default_empty(self) -> None:
         """Test that sender_rules defaults to empty list."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -231,7 +232,7 @@ class TestAccountConfig:
 
     def test_sender_rules_with_rules(self) -> None:
         """Test sender_rules with configured rules."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -247,7 +248,7 @@ class TestAccountConfig:
 
     def test_subject_rules_default_empty(self) -> None:
         """Test that subject_rules defaults to empty list."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -256,7 +257,7 @@ class TestAccountConfig:
 
     def test_subject_rules_with_rules(self) -> None:
         """Test subject_rules with configured rules."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -269,7 +270,7 @@ class TestAccountConfig:
 
     def test_list_prompts_default_empty(self) -> None:
         """Test that list_prompts defaults to empty dict."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -278,7 +279,7 @@ class TestAccountConfig:
 
     def test_list_prompts_with_custom_prompts(self) -> None:
         """Test list_prompts with custom prompts."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -292,7 +293,7 @@ class TestAccountConfig:
 
     def test_read_prompts_default_empty(self) -> None:
         """Test that read_prompts defaults to empty dict."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -301,7 +302,7 @@ class TestAccountConfig:
 
     def test_read_prompts_with_custom_prompts(self) -> None:
         """Test read_prompts with custom prompts."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -313,7 +314,7 @@ class TestAccountConfig:
 
     def test_full_access_rules_config(self) -> None:
         """Test complete access rules configuration."""
-        config = AccountConfig(
+        config = IMAPAccountConfig(
             id="work",
             host="mail.example.com",
             username="user",
@@ -401,10 +402,6 @@ class TestBaseAccountConfig:
         )
         assert isinstance(config, BaseAccountConfig)
 
-    def test_account_config_alias_is_imap(self) -> None:
-        """AccountConfig type alias resolves to IMAPAccountConfig."""
-        assert AccountConfig is IMAPAccountConfig
-
     def test_shared_fields_live_on_base(self) -> None:
         """Fields shared across account types are defined on BaseAccountConfig."""
         base_fields = BaseAccountConfig.model_fields
@@ -426,3 +423,97 @@ class TestBaseAccountConfig:
         base_fields = BaseAccountConfig.model_fields
         for field in ("host", "port", "username", "ssl", "type"):
             assert field not in base_fields, f"'{field}' should not be on BaseAccountConfig"
+
+
+class TestGmailAccountConfig:
+    """Tests for GmailAccountConfig."""
+
+    def test_valid_gmail_config(self) -> None:
+        """Test creating a valid GmailAccountConfig."""
+        config = GmailAccountConfig(
+            id="gmail-personal",
+            email="user@gmail.com",
+            credentials_file="/path/to/credentials.json",
+        )
+        assert config.id == "gmail-personal"
+        assert config.type == "gmail"
+        assert config.email == "user@gmail.com"
+        assert config.credentials_file == "/path/to/credentials.json"
+        assert config.token_file == "gmail_token.json"
+        assert config.from_address is None
+        assert config.from_name is None
+
+    def test_gmail_config_with_custom_token_file(self) -> None:
+        """Test GmailAccountConfig with custom token file."""
+        config = GmailAccountConfig(
+            id="gmail-work",
+            email="work@gmail.com",
+            credentials_file="/path/to/credentials.json",
+            token_file="/custom/token.json",
+        )
+        assert config.token_file == "/custom/token.json"
+
+    def test_gmail_config_with_from_address(self) -> None:
+        """Test GmailAccountConfig with from_address and from_name."""
+        config = GmailAccountConfig(
+            id="gmail-work",
+            email="work@gmail.com",
+            credentials_file="/path/to/credentials.json",
+            from_address="alias@gmail.com",
+            from_name="Atlas",
+        )
+        assert config.from_address == "alias@gmail.com"
+        assert config.from_name == "Atlas"
+
+    def test_gmail_config_inherits_from_base(self) -> None:
+        """GmailAccountConfig inherits from BaseAccountConfig."""
+        config = GmailAccountConfig(
+            id="gmail-personal",
+            email="user@gmail.com",
+            credentials_file="/path/to/credentials.json",
+        )
+        assert isinstance(config, BaseAccountConfig)
+
+    def test_gmail_config_has_base_fields(self) -> None:
+        """GmailAccountConfig inherits shared fields from BaseAccountConfig."""
+        config = GmailAccountConfig(
+            id="gmail-personal",
+            email="user@gmail.com",
+            credentials_file="/path/to/credentials.json",
+        )
+        assert config.permissions is not None
+        assert config.protection is None
+        assert config.sender_rules == []
+        assert config.subject_rules == []
+
+    def test_discriminated_union_parses_gmail_type(self) -> None:
+        """Test AccountConfig discriminated union correctly parses type='gmail'."""
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(AccountConfig)
+        config = adapter.validate_python(
+            {
+                "type": "gmail",
+                "id": "my-gmail",
+                "email": "user@gmail.com",
+                "credentials_file": "/path/to/creds.json",
+            }
+        )
+        assert isinstance(config, GmailAccountConfig)
+        assert config.type == "gmail"
+        assert config.email == "user@gmail.com"
+
+    def test_discriminated_union_parses_imap_type(self) -> None:
+        """Test AccountConfig discriminated union still parses type='imap'."""
+        from pydantic import TypeAdapter
+
+        adapter = TypeAdapter(AccountConfig)
+        config = adapter.validate_python(
+            {
+                "type": "imap",
+                "id": "my-imap",
+                "host": "mail.example.com",
+                "username": "user@example.com",
+            }
+        )
+        assert isinstance(config, IMAPAccountConfig)

--- a/tests/email/connectors/test_gmail.py
+++ b/tests/email/connectors/test_gmail.py
@@ -1,0 +1,660 @@
+"""Tests for Gmail connector."""
+
+import base64
+import os
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from read_no_evil_mcp.email.connectors.config import GmailConfig
+from read_no_evil_mcp.email.connectors.gmail import (
+    GmailConnector,
+    _extract_body_parts,
+    _get_header,
+    _parse_address,
+    _parse_address_list,
+    _parse_date,
+)
+
+
+class TestHelpers:
+    """Tests for module-level helper functions."""
+
+    def test_parse_address_with_name(self) -> None:
+        result = _parse_address("John Doe <john@example.com>")
+        assert result.name == "John Doe"
+        assert result.address == "john@example.com"
+
+    def test_parse_address_without_name(self) -> None:
+        result = _parse_address("john@example.com")
+        assert result.name is None
+        assert result.address == "john@example.com"
+
+    def test_parse_address_empty_string(self) -> None:
+        result = _parse_address("")
+        assert result.address == "unknown@unknown"
+
+    def test_parse_address_invalid(self) -> None:
+        result = _parse_address("not-an-email")
+        assert result.address == "not-an-email"
+
+    def test_parse_address_list_multiple(self) -> None:
+        result = _parse_address_list("alice@example.com, Bob <bob@example.com>")
+        assert len(result) == 2
+        assert result[0].address == "alice@example.com"
+        assert result[1].name == "Bob"
+        assert result[1].address == "bob@example.com"
+
+    def test_parse_address_list_empty(self) -> None:
+        result = _parse_address_list("")
+        assert result == []
+
+    def test_parse_address_list_single(self) -> None:
+        result = _parse_address_list("alice@example.com")
+        assert len(result) == 1
+        assert result[0].address == "alice@example.com"
+
+    def test_get_header_found(self) -> None:
+        headers = [
+            {"name": "From", "value": "sender@example.com"},
+            {"name": "Subject", "value": "Test Subject"},
+        ]
+        assert _get_header(headers, "Subject") == "Test Subject"
+
+    def test_get_header_case_insensitive(self) -> None:
+        headers = [{"name": "FROM", "value": "sender@example.com"}]
+        assert _get_header(headers, "from") == "sender@example.com"
+
+    def test_get_header_not_found(self) -> None:
+        headers = [{"name": "From", "value": "sender@example.com"}]
+        assert _get_header(headers, "Subject") == ""
+
+    def test_parse_date_valid(self) -> None:
+        result = _parse_date("Mon, 17 Feb 2026 10:00:00 +0000")
+        assert result.year == 2026
+        assert result.month == 2
+        assert result.day == 17
+
+    def test_parse_date_invalid_returns_now(self) -> None:
+        result = _parse_date("not-a-date")
+        assert isinstance(result, datetime)
+        # Should be close to now
+        assert (datetime.now(timezone.utc) - result).total_seconds() < 5
+
+    def test_extract_body_parts_plain_text(self) -> None:
+        data = base64.urlsafe_b64encode(b"Hello plain").decode()
+        payload: dict[str, object] = {
+            "mimeType": "text/plain",
+            "filename": "",
+            "body": {"data": data},
+        }
+        plain, html, attachments = _extract_body_parts(payload)
+        assert plain == "Hello plain"
+        assert html is None
+        assert attachments == []
+
+    def test_extract_body_parts_html(self) -> None:
+        data = base64.urlsafe_b64encode(b"<p>Hello</p>").decode()
+        payload: dict[str, object] = {
+            "mimeType": "text/html",
+            "filename": "",
+            "body": {"data": data},
+        }
+        plain, html, attachments = _extract_body_parts(payload)
+        assert plain is None
+        assert html == "<p>Hello</p>"
+
+    def test_extract_body_parts_multipart(self) -> None:
+        plain_data = base64.urlsafe_b64encode(b"Plain body").decode()
+        html_data = base64.urlsafe_b64encode(b"<p>HTML body</p>").decode()
+        payload: dict[str, object] = {
+            "mimeType": "multipart/alternative",
+            "filename": "",
+            "body": {"size": 0},
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "filename": "",
+                    "body": {"data": plain_data},
+                },
+                {
+                    "mimeType": "text/html",
+                    "filename": "",
+                    "body": {"data": html_data},
+                },
+            ],
+        }
+        plain, html, attachments = _extract_body_parts(payload)
+        assert plain == "Plain body"
+        assert html == "<p>HTML body</p>"
+        assert attachments == []
+
+    def test_extract_body_parts_with_attachment(self) -> None:
+        payload: dict[str, object] = {
+            "mimeType": "multipart/mixed",
+            "filename": "",
+            "body": {"size": 0},
+            "parts": [
+                {
+                    "mimeType": "text/plain",
+                    "filename": "",
+                    "body": {"data": base64.urlsafe_b64encode(b"Body").decode()},
+                },
+                {
+                    "mimeType": "application/pdf",
+                    "filename": "report.pdf",
+                    "body": {"size": 1024},
+                },
+            ],
+        }
+        plain, html, attachments = _extract_body_parts(payload)
+        assert plain == "Body"
+        assert len(attachments) == 1
+        assert attachments[0].filename == "report.pdf"
+        assert attachments[0].content_type == "application/pdf"
+        assert attachments[0].size == 1024
+
+    def test_extract_body_parts_no_data(self) -> None:
+        payload: dict[str, object] = {
+            "mimeType": "text/plain",
+            "filename": "",
+            "body": {},
+        }
+        plain, html, attachments = _extract_body_parts(payload)
+        assert plain is None
+        assert html is None
+        assert attachments == []
+
+
+class TestGmailConnector:
+    @pytest.fixture
+    def config(self) -> GmailConfig:
+        return GmailConfig(
+            credentials_file="/path/to/credentials.json",
+            token_file="/path/to/token.json",
+        )
+
+    def test_init(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        assert connector.config == config
+        assert connector._service is None
+        assert connector._creds is None
+
+    @patch("read_no_evil_mcp.email.connectors.gmail.build")
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.fdopen", new_callable=mock_open)
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.open", return_value=99)
+    @patch("read_no_evil_mcp.email.connectors.gmail.InstalledAppFlow")
+    @patch("read_no_evil_mcp.email.connectors.gmail.Credentials")
+    def test_connect_new_oauth_flow(
+        self,
+        mock_creds_class: MagicMock,
+        mock_flow_class: MagicMock,
+        mock_os_open: MagicMock,
+        mock_os_fdopen: MagicMock,
+        mock_build: MagicMock,
+        config: GmailConfig,
+    ) -> None:
+        """Test connect runs OAuth flow when no existing token."""
+        mock_creds_class.from_authorized_user_file.side_effect = FileNotFoundError
+        mock_flow = MagicMock()
+        mock_flow_class.from_client_secrets_file.return_value = mock_flow
+        mock_new_creds = MagicMock()
+        mock_new_creds.to_json.return_value = '{"token": "new"}'
+        mock_flow.run_local_server.return_value = mock_new_creds
+
+        connector = GmailConnector(config)
+        connector.connect()
+
+        mock_flow_class.from_client_secrets_file.assert_called_once_with(
+            "/path/to/credentials.json",
+            ["https://www.googleapis.com/auth/gmail.readonly"],
+        )
+        mock_flow.run_local_server.assert_called_once_with(port=0)
+        mock_build.assert_called_once_with("gmail", "v1", credentials=mock_new_creds)
+        assert connector._service is not None
+        assert connector._creds is mock_new_creds
+
+    @patch("read_no_evil_mcp.email.connectors.gmail.build")
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.fdopen", new_callable=mock_open)
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.open", return_value=99)
+    @patch("read_no_evil_mcp.email.connectors.gmail.Credentials")
+    def test_connect_with_valid_token(
+        self,
+        mock_creds_class: MagicMock,
+        mock_os_open: MagicMock,
+        mock_os_fdopen: MagicMock,
+        mock_build: MagicMock,
+        config: GmailConfig,
+    ) -> None:
+        """Test connect uses existing valid token."""
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.expired = False
+        mock_creds.to_json.return_value = '{"token": "existing"}'
+        mock_creds_class.from_authorized_user_file.return_value = mock_creds
+
+        connector = GmailConnector(config)
+        connector.connect()
+
+        mock_build.assert_called_once_with("gmail", "v1", credentials=mock_creds)
+        assert connector._creds is mock_creds
+
+    @patch("read_no_evil_mcp.email.connectors.gmail.build")
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.fdopen", new_callable=mock_open)
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.open", return_value=99)
+    @patch("read_no_evil_mcp.email.connectors.gmail.Request")
+    @patch("read_no_evil_mcp.email.connectors.gmail.Credentials")
+    def test_connect_refreshes_expired_token(
+        self,
+        mock_creds_class: MagicMock,
+        mock_request_class: MagicMock,
+        mock_os_open: MagicMock,
+        mock_os_fdopen: MagicMock,
+        mock_build: MagicMock,
+        config: GmailConfig,
+    ) -> None:
+        """Test connect refreshes expired token."""
+        mock_creds = MagicMock()
+        mock_creds.valid = False
+        mock_creds.expired = True
+        mock_creds.refresh_token = "refresh-token"
+        mock_creds.to_json.return_value = '{"token": "refreshed"}'
+        mock_creds_class.from_authorized_user_file.return_value = mock_creds
+
+        connector = GmailConnector(config)
+        connector.connect()
+
+        mock_creds.refresh.assert_called_once_with(mock_request_class.return_value)
+        mock_build.assert_called_once_with("gmail", "v1", credentials=mock_creds)
+
+    @patch("read_no_evil_mcp.email.connectors.gmail.build")
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.fdopen", new_callable=mock_open)
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.open", return_value=99)
+    @patch("read_no_evil_mcp.email.connectors.gmail.InstalledAppFlow")
+    @patch("read_no_evil_mcp.email.connectors.gmail.Credentials")
+    def test_connect_writes_token_with_restricted_permissions(
+        self,
+        mock_creds_class: MagicMock,
+        mock_flow_class: MagicMock,
+        mock_os_open: MagicMock,
+        mock_os_fdopen: MagicMock,
+        mock_build: MagicMock,
+        config: GmailConfig,
+    ) -> None:
+        """Test connect creates token file with 0o600 permissions."""
+        mock_creds_class.from_authorized_user_file.side_effect = FileNotFoundError
+        mock_flow = MagicMock()
+        mock_flow_class.from_client_secrets_file.return_value = mock_flow
+        mock_new_creds = MagicMock()
+        mock_new_creds.to_json.return_value = '{"token": "new"}'
+        mock_flow.run_local_server.return_value = mock_new_creds
+
+        connector = GmailConnector(config)
+        connector.connect()
+
+        mock_os_open.assert_called_once_with(
+            "/path/to/token.json",
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+
+    def test_disconnect(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        connector._service = MagicMock()
+        connector._creds = MagicMock()
+
+        connector.disconnect()
+
+        assert connector._service is None
+        assert connector._creds is None
+
+    @patch("read_no_evil_mcp.email.connectors.gmail.build")
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.fdopen", new_callable=mock_open)
+    @patch("read_no_evil_mcp.email.connectors.gmail.os.open", return_value=99)
+    @patch("read_no_evil_mcp.email.connectors.gmail.Credentials")
+    def test_context_manager(
+        self,
+        mock_creds_class: MagicMock,
+        mock_os_open: MagicMock,
+        mock_os_fdopen: MagicMock,
+        mock_build: MagicMock,
+        config: GmailConfig,
+    ) -> None:
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.expired = False
+        mock_creds.to_json.return_value = '{"token": "t"}'
+        mock_creds_class.from_authorized_user_file.return_value = mock_creds
+
+        with GmailConnector(config) as connector:
+            assert connector._service is not None
+
+        assert connector._service is None
+        assert connector._creds is None
+
+    def test_list_folders(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+        mock_service.users().labels().list().execute.return_value = {
+            "labels": [
+                {"id": "INBOX", "type": "system"},
+                {"id": "SENT", "type": "system"},
+                {"id": "Label_1", "type": "user"},
+            ]
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        folders = connector.list_folders()
+
+        assert len(folders) == 3
+        assert folders[0].name == "INBOX"
+        assert folders[0].delimiter == "/"
+        assert folders[0].flags == ["system"]
+        assert folders[2].name == "Label_1"
+        assert folders[2].flags == ["user"]
+
+    def test_list_folders_not_connected(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            connector.list_folders()
+
+    def test_fetch_emails(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+
+        # Mock messages.list response
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "msg_1"}]
+        }
+
+        # Mock messages.get for metadata
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_1",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "Alice <alice@example.com>"},
+                    {"name": "Subject", "value": "Hello"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                ]
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7))
+
+        assert len(emails) == 1
+        assert emails[0].uid == "msg_1"
+        assert emails[0].subject == "Hello"
+        assert emails[0].sender.name == "Alice"
+        assert emails[0].sender.address == "alice@example.com"
+        assert emails[0].is_seen is True  # No UNREAD label
+        assert emails[0].folder == "INBOX"
+
+    def test_fetch_emails_unread(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "msg_2"}]
+        }
+
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_2",
+            "labelIds": ["INBOX", "UNREAD"],
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "bob@example.com"},
+                    {"name": "Subject", "value": "Unread email"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                ]
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7))
+
+        assert len(emails) == 1
+        assert emails[0].is_seen is False
+
+    def test_fetch_emails_with_limit(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "msg_1"}, {"id": "msg_2"}, {"id": "msg_3"}]
+        }
+
+        # Each message get
+        mock_service.users().messages().get().execute.side_effect = [
+            {
+                "id": f"msg_{i}",
+                "labelIds": ["INBOX"],
+                "payload": {
+                    "headers": [
+                        {"name": "From", "value": f"user{i}@example.com"},
+                        {"name": "Subject", "value": f"Subject {i}"},
+                        {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                    ]
+                },
+            }
+            for i in range(1, 4)
+        ]
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7), limit=2)
+
+        assert len(emails) == 2
+
+    def test_fetch_emails_unread_only(self, config: GmailConfig) -> None:
+        """Test fetch_emails builds query with is:unread when unread_only=True."""
+        mock_service = MagicMock()
+        mock_service.users().messages().list().execute.return_value = {"messages": []}
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        connector.fetch_emails("INBOX", lookback=timedelta(days=7), unread_only=True)
+
+        # Verify the query parameter includes is:unread
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        assert "is:unread" in call_kwargs["q"]
+
+    def test_fetch_emails_with_from_date(self, config: GmailConfig) -> None:
+        """Test fetch_emails uses from_date for query range."""
+        mock_service = MagicMock()
+        mock_service.users().messages().list().execute.return_value = {"messages": []}
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        connector.fetch_emails(
+            "INBOX",
+            lookback=timedelta(days=3),
+            from_date=date(2026, 2, 15),
+        )
+
+        call_kwargs = mock_service.users().messages().list.call_args.kwargs
+        assert "after:2026/02/12" in call_kwargs["q"]
+        assert "before:2026/02/16" in call_kwargs["q"]
+
+    def test_fetch_emails_not_connected(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            connector.fetch_emails("INBOX", lookback=timedelta(days=7))
+
+    def test_fetch_emails_has_attachments_always_false(self, config: GmailConfig) -> None:
+        """fetch_emails uses metadata format which doesn't include parts,
+        so has_attachments is always False. get_email detects attachments."""
+        mock_service = MagicMock()
+
+        mock_service.users().messages().list().execute.return_value = {
+            "messages": [{"id": "msg_att"}]
+        }
+
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_att",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Subject", "value": "With attachment"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                ],
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        emails = connector.fetch_emails("INBOX", lookback=timedelta(days=7))
+
+        assert len(emails) == 1
+        assert emails[0].has_attachments is False
+
+    def test_get_email(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+
+        plain_data = base64.urlsafe_b64encode(b"Plain text body").decode()
+        html_data = base64.urlsafe_b64encode(b"<p>HTML body</p>").decode()
+
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_full",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "mimeType": "multipart/alternative",
+                "filename": "",
+                "headers": [
+                    {"name": "From", "value": "Sender <sender@example.com>"},
+                    {"name": "Subject", "value": "Full Email"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                    {"name": "To", "value": "recipient@example.com"},
+                    {"name": "Cc", "value": "cc@example.com"},
+                    {"name": "Message-ID", "value": "<abc@example.com>"},
+                ],
+                "body": {"size": 0},
+                "parts": [
+                    {
+                        "mimeType": "text/plain",
+                        "filename": "",
+                        "body": {"data": plain_data},
+                    },
+                    {
+                        "mimeType": "text/html",
+                        "filename": "",
+                        "body": {"data": html_data},
+                    },
+                ],
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        email = connector.get_email("INBOX", "msg_full")
+
+        assert email is not None
+        assert email.uid == "msg_full"
+        assert email.subject == "Full Email"
+        assert email.sender.name == "Sender"
+        assert email.sender.address == "sender@example.com"
+        assert email.body_plain == "Plain text body"
+        assert email.body_html == "<p>HTML body</p>"
+        assert len(email.to) == 1
+        assert email.to[0].address == "recipient@example.com"
+        assert len(email.cc) == 1
+        assert email.cc[0].address == "cc@example.com"
+        assert email.message_id == "<abc@example.com>"
+        assert email.is_seen is True
+        assert email.folder == "INBOX"
+
+    def test_get_email_returns_none_on_api_error(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+        mock_service.users().messages().get().execute.side_effect = Exception("API error")
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        email = connector.get_email("INBOX", "bad_id")
+
+        assert email is None
+
+    def test_get_email_not_connected(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        with pytest.raises(RuntimeError, match="Not connected"):
+            connector.get_email("INBOX", "msg_1")
+
+    def test_get_email_unseen(self, config: GmailConfig) -> None:
+        mock_service = MagicMock()
+
+        plain_data = base64.urlsafe_b64encode(b"Body").decode()
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_unseen",
+            "labelIds": ["INBOX", "UNREAD"],
+            "payload": {
+                "mimeType": "text/plain",
+                "filename": "",
+                "headers": [
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Subject", "value": "Unseen"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                ],
+                "body": {"data": plain_data},
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        email = connector.get_email("INBOX", "msg_unseen")
+
+        assert email is not None
+        assert email.is_seen is False
+
+    def test_get_email_no_subject(self, config: GmailConfig) -> None:
+        """Test get_email falls back to '(no subject)' when Subject header is missing."""
+        mock_service = MagicMock()
+
+        plain_data = base64.urlsafe_b64encode(b"Body").decode()
+        mock_service.users().messages().get().execute.return_value = {
+            "id": "msg_nosub",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "mimeType": "text/plain",
+                "filename": "",
+                "headers": [
+                    {"name": "From", "value": "sender@example.com"},
+                    {"name": "Date", "value": "Mon, 17 Feb 2026 10:00:00 +0000"},
+                ],
+                "body": {"data": plain_data},
+            },
+        }
+
+        connector = GmailConnector(config)
+        connector._service = mock_service
+
+        email = connector.get_email("INBOX", "msg_nosub")
+
+        assert email is not None
+        assert email.subject == "(no subject)"
+
+    def test_move_email_raises_not_implemented(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        with pytest.raises(NotImplementedError, match="GmailConnector does not support move_email"):
+            connector.move_email("INBOX", "msg_1", "Archive")
+
+    def test_delete_email_raises_not_implemented(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        with pytest.raises(
+            NotImplementedError, match="GmailConnector does not support delete_email"
+        ):
+            connector.delete_email("INBOX", "msg_1")
+
+    def test_can_send_returns_false(self, config: GmailConfig) -> None:
+        connector = GmailConnector(config)
+        assert connector.can_send() is False

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -558,6 +559,90 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/10/05572d33273292bac49c2d1785925f7bc3ff2fe50e3044cf1062c1dde32e/google_api_core-2.29.0.tar.gz", hash = "sha256:84181be0f8e6b04006df75ddfe728f24489f0af57c96a529ff7cf45bc28797f7", size = 177828, upload-time = "2026-01-08T22:21:39.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/b6/85c4d21067220b9a78cfb81f516f9725ea6befc1544ec9bd2c1acd97c324/google_api_core-2.29.0-py3-none-any.whl", hash = "sha256:d30bc60980daa36e314b5d5a3e5958b0200cb44ca8fa1be2b614e932b75a3ea9", size = 173906, upload-time = "2026-01-08T22:21:36.093Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.190.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/4ab3e3516b93bb50ed7814738ea61d49cba3f72f4e331dc9518ae2731e92/google_api_python_client-2.190.0.tar.gz", hash = "sha256:5357f34552e3724d80d2604c8fa146766e0a9d6bb0afada886fafed9feafeef6", size = 14111143, upload-time = "2026-02-12T00:38:03.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/ad/223d5f4b0b987669ffeb3eadd7e9f85ece633aa7fd3246f1e2f6238e1e05/google_api_python_client-2.190.0-py3-none-any.whl", hash = "sha256:d9b5266758f96c39b8c21d9bbfeb4e58c14dbfba3c931f7c5a8d7fdcd292dd57", size = 14682070, upload-time = "2026-02-12T00:38:00.974Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/ad/c1f2b1175096a8d04cf202ad5ea6065f108d26be6fc7215876bde4a7981d/google_auth_httplib2-0.3.0.tar.gz", hash = "sha256:177898a0175252480d5ed916aeea183c2df87c1f9c26705d74ae6b951c268b0b", size = 11134, upload-time = "2025-12-15T22:13:51.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/d5/3c97526c8796d3caf5f4b3bed2b05e8a7102326f00a334e7a438237f3b22/google_auth_httplib2-0.3.0-py3-none-any.whl", hash = "sha256:426167e5df066e3f5a0fc7ea18768c08e7296046594ce4c8c409c2457dd1f776", size = 9529, upload-time = "2025-12-15T22:13:51.048Z" },
+]
+
+[[package]]
+name = "google-auth-oauthlib"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "requests-oauthlib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/dd/211f27c1e927e2292c2a71d5df1a2aaf261ce50ba7d50848c6ee24e20970/google_auth_oauthlib-1.2.4.tar.gz", hash = "sha256:3ca93859c6cc9003c8e12b2a0868915209d7953f05a70f4880ab57d57e56ee3e", size = 21185, upload-time = "2026-01-15T22:03:10.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/21/fb96db432d187b07756e62971c4d89bdef70259e4cfa76ee32bcc0ac97d1/google_auth_oauthlib-1.2.4-py3-none-any.whl", hash = "sha256:0e922eea5f2baacaf8867febb782e46e7b153236c21592ed76ab3ddb77ffd772", size = 19193, upload-time = "2026-01-15T22:03:09.046Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -606,6 +691,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -1184,7 +1281,8 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
@@ -1262,7 +1360,8 @@ name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
@@ -1475,6 +1574,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1563,6 +1671,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/02/8832cde80e7380c600fbf55090b6ab7b62bd6825dbedde6d6657c15a1f8e/proto_plus-1.27.1.tar.gz", hash = "sha256:912a7460446625b792f6448bade9e55cd4e41e6ac10e27009ef71a7f317fa147", size = 56929, upload-time = "2026-02-02T17:34:49.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/79/ac273cbbf744691821a9cca88957257f41afe271637794975ca090b9588b/proto_plus-1.27.1-py3-none-any.whl", hash = "sha256:e4643061f3a4d0de092d62aa4ad09fa4756b2cbb89d4627f3985018216f9fefc", size = 50480, upload-time = "2026-02-02T17:34:47.339Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1601,6 +1736,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1812,6 +1968,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2001,6 +2166,8 @@ version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
+    { name = "google-api-python-client" },
+    { name = "google-auth-oauthlib" },
     { name = "imap-tools" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -2021,6 +2188,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=2.14.5" },
+    { name = "google-api-python-client", specifier = ">=2.0" },
+    { name = "google-auth-oauthlib", specifier = ">=1.0" },
     { name = "imap-tools" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -2198,6 +2367,19 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2343,6 +2525,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -2737,6 +2931,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implements `GmailConnector(BaseConnector)` for reading emails via the Gmail API with OAuth2 authentication
- Adds `GmailConfig` and `GmailAccountConfig` with discriminated union on the `type` field
- Wires the connector into `AccountService._create_connector()` factory
- Adds 52 unit tests with mocked Gmail API responses
- Updates CONFIGURATION.md with Gmail setup instructions

## Acceptance criteria

- [x] Can list Gmail labels as folders
- [x] Can fetch email summaries from a label/folder
- [x] Can read full email content (plain text + HTML + attachments metadata)
- [x] Prompt injection scanning works on Gmail emails (uses same `Email` model)
- [x] All existing IMAP tests still pass (791 tests, 0 failures)
- [x] `move_email()` / `delete_email()` raise `NotImplementedError`

## Test plan

- [x] All 791 tests pass (`uv run pytest`)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy src/` passes with no errors
- [ ] Manual testing with a real Gmail account and OAuth credentials

Closes #285